### PR TITLE
fix: add missing `name` and `names` to `ESMExport` interface

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -28,7 +28,9 @@ export interface ESMExport {
   type: 'declaration' | 'named' | 'default',
   code: string
   start: number
-  end: number
+  end: number,
+  name?: string,
+  names?: string[]
 }
 
 export interface DeclarationExport extends ESMExport {


### PR DESCRIPTION
Point to https://github.com/nuxt/framework/blob/main/packages/nuxt3/src/auto-imports/composables.ts#L22

As it used ESMExport[]. We should give all possible default values to improve the typing here.

![Screen Shot 2021-10-22 at 3 58 34 PM](https://user-images.githubusercontent.com/11556276/138466708-a5c09c86-de67-4486-a744-ba075e9a2beb.png)


