### PR TITLE
fix: exclude windows drive letters from protocols

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -39,7 +39,8 @@ export function matchAll (regex, string, addition) {
   return matches
 }
 
-const ProtocolRegex = /^(?<proto>.+):.+$/
+// 2+ letters, to exclude Windows drive letters
+const ProtocolRegex = /^(?<proto>.{2,}):.+$/
 
 export function getProtocol (id: string): string | null {
   const proto = id.match(ProtocolRegex)


### PR DESCRIPTION
resolves https://github.com/nuxt/framework/issues/1559
resolves https://github.com/nuxt/framework/issues/1573

will also want to port to externality's identical util