### PR TITLE
docs: fix resolve url argument

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ console.log(await resolve('./module.mjs', { url: import.meta.url }))
 
 **Resolve options:**
 
-- `from`: URL or string (default is `pwd()`)
+- `url`: URL or string to resolve from (default is `pwd()`)
 - `conditions`: Array of conditions used for resolution algorithm (default is `['node', 'import']`)
 - `extensions`: Array of additional extensions to check if import failed (default is `['.mjs', '.cjs', '.js', '.json']`)
 


### PR DESCRIPTION
The typescript definition for the second argument is :

```ts
interface ResolveOptions {
    url?: string | URL | (string | URL)[];
    extensions?: string[];
    conditions?: string[];
}
```

Guessing this is a doc inconsistency as the code example uses `url` 