### PR TITLE
fix: get actual protocol for windows instead of protocol + drive

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -38,12 +38,3 @@ export function matchAll (regex, string, addition) {
   }
   return matches
 }
-
-// 2+ letters, to exclude Windows drive letters
-// "{2,}?" to make in ungreedy and dont take "file://C" as protocol
-const ProtocolRegex = /^(?<proto>.{2,}?):.+$/
-
-export function getProtocol (id: string): string | null {
-  const proto = id.match(ProtocolRegex)
-  return proto ? proto.groups.proto : null
-}

--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -40,7 +40,8 @@ export function matchAll (regex, string, addition) {
 }
 
 // 2+ letters, to exclude Windows drive letters
-const ProtocolRegex = /^(?<proto>.{2,}):.+$/
+// "{2,}?" to make in ungreedy and dont take "file://C" as protocol
+const ProtocolRegex = /^(?<proto>.{2,}?):.+$/
 
 export function getProtocol (id: string): string | null {
   const proto = id.match(ProtocolRegex)

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -2,8 +2,7 @@ import { promises as fsp } from 'fs'
 import { extname } from 'pathe'
 import { readPackageJSON } from 'pkg-types'
 import { ResolveOptions, resolvePath } from './resolve'
-import { isNodeBuiltin } from './utils'
-import { getProtocol } from './_utils'
+import { isNodeBuiltin, getProtocol } from './utils'
 
 const ESM_RE = /([\s;]|^)(import[\w,{}\s*]*from|import\s*['"*{]|export\b\s*(?:[*{]|default|type|function|const|var|let|async function)|import\.meta\b)/m
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -51,3 +51,12 @@ export function isNodeBuiltin (id: string = '') {
   id = id.replace(/^node:/, '').split('/')[0]
   return BUILTIN_MODULES.has(id)
 }
+
+// 2+ letters, to exclude Windows drive letters
+// "{2,}?" to make in ungreedy and dont take "file://C" as protocol
+const ProtocolRegex = /^(?<proto>.{2,}?):.+$/
+
+export function getProtocol (id: string): string | null {
+  const proto = id.match(ProtocolRegex)
+  return proto ? proto.groups.proto : null
+}

--- a/test/utils.test.mjs
+++ b/test/utils.test.mjs
@@ -1,4 +1,4 @@
-import { isNodeBuiltin, sanitizeFilePath } from 'mlly'
+import { isNodeBuiltin, sanitizeFilePath, getProtocol } from 'mlly'
 import { expect } from 'chai'
 
 describe('isNodeBuiltin', () => {
@@ -39,5 +39,18 @@ describe('sanitizeFilePath', () => {
 
   it('undefined', () => {
     expect(sanitizeFilePath()).to.equal('')
+  })
+})
+
+describe('getProtocol', () => {
+  it('no protocol', () => {
+    expect(getProtocol('/src/a.ts')).to.equal(null)
+    expect(getProtocol('C:/src/a.ts')).to.equal(null)
+  })
+
+  it('file protocol', () => {
+    expect(getProtocol('file://src/a.ts')).to.equal('file')
+    expect(getProtocol('file://C:/src/a.ts')).to.equal('file')
+    expect(getProtocol('file:///C:/src/a.ts')).to.equal('file')
   })
 })


### PR DESCRIPTION
On windows current regexp from this url gets incorrect protocol:

```
file:///C:/path
```
- Incorrect: `file:///C`
- Correct: `file`

This PR fixes it making `{2,}` ungreedy, so it will end after the first `:`. (You can test it in https://regex101.com/)

Related: https://github.com/vitest-dev/vitest/issues/379