### PR TITLE
fix: make "url" optional in resolver created with createResolve

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -118,7 +118,7 @@ export function resolvePath (id: string, opts?: ResolveOptions) {
 }
 
 export function createResolve (defaults?: ResolveOptions) {
-  return (id, url) => {
+  return (id: string, url?: ResolveOptions['url']) => {
     return resolve(id, { url, ...defaults })
   }
 }

--- a/test/fixture/eval-err.mjs
+++ b/test/fixture/eval-err.mjs
@@ -1,4 +1,6 @@
-async function test() {
+// @ts-nocheck
+// eslint-disable-next-line require-await
+async function test () {
   throw new Error('Something went wrong in eval-err module!')
 }
 

--- a/test/fixture/resolve.mjs
+++ b/test/fixture/resolve.mjs
@@ -1,9 +1,9 @@
 import { resolvePath, createResolve, resolveImports } from 'mlly'
 
-import.meta.resolve = createResolve({ url: import.meta.url })
-console.log(await import.meta.resolve('./cjs.mjs'))
+const resolve = createResolve({ url: import.meta.url })
+console.log(await resolve('./cjs.mjs'))
 
 console.log(await resolvePath('./cjs.mjs', { url: import.meta.url }))
 console.log(await resolvePath('./foo', { url: import.meta.url }))
 
-console.log(await resolveImports(`import foo from './eval.mjs'`, { url: import.meta.url }))
+console.log(await resolveImports('import foo from \'./eval.mjs\'', { url: import.meta.url }))

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -3,7 +3,12 @@
     "target": "ESNext",
     "module": "ESNext",
     "moduleResolution": "Node",
+    "resolveJsonModule": true,
     "esModuleInterop": true,
+    "checkJs": true,
+    "paths": {
+      "mlly": ["./"]
+    },
     "types": [
       "node"
     ]


### PR DESCRIPTION
- The `url` argument to resolver created with `createResolve` is made optional. The point is that the defaults are used and the `url` doesn't have to be provided, same as in Node's `import.meta.resolve` API.
- Enable `checkJS` so that the `*.mjs` files in `test/fixture` are least type checked (mostly for the editor's sake).
- Add `mlly` path mapping in `tsconfig.json` so that there are no errors reported in `test/fixture` when importing from `mlly`.