### PR TITLE
feat(findExports): support named star export

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -57,7 +57,7 @@ export const DYNAMIC_IMPORT_RE = /import\s*\((?<expression>(?:[^)(]+|\((?:[^)(]+
 
 export const EXPORT_DECAL_RE = /\bexport\s+(?<declaration>(async function|function|let|const|var|class))\s+(?<name>[\w$_]+)/g
 const EXPORT_NAMED_RE = /\bexport\s+{(?<exports>[^}]+)}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^"\s](?=\s*")|(?<='\s*)[^']*[^'\s](?=\s*'))\s*["'][^\n]*)?/g
-const EXPORT_STAR_RE = /\bexport\s*(\*)\s*(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^"\s](?=\s*")|(?<='\s*)[^']*[^'\s](?=\s*'))\s*["'][^\n]*)?/g
+const EXPORT_STAR_RE = /\bexport\s*(\*)(\s*as\s+(?<name>[\w$_]+)\s+)?\s*(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^"\s](?=\s*")|(?<='\s*)[^']*[^'\s](?=\s*'))\s*["'][^\n]*)?/g
 const EXPORT_DEFAULT_RE = /\bexport\s+default\s+/g
 
 export function findStaticImports (code: string): StaticImport[] {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -11,7 +11,8 @@ describe('findExports', () => {
     'export async function foo ()': { type: 'declaration', names: ['foo'] },
     'export const $foo = () => {}': { type: 'declaration', names: ['$foo'] },
     'export { foo as default }': { type: 'default', name: 'default', names: ['default'] },
-    'export * from "./other"': { type: 'star', specifier: './other' }
+    'export * from "./other"': { type: 'star', specifier: './other' },
+    'export * as foo from "./other"': { type: 'star', specifier: './other', name: 'foo' }
   }
 
   describe('findExports', () => {


### PR DESCRIPTION
Add support for star exports with name
```js
export * as foo from 'file'
```
Previously, parsing result was:
```js
{
    type: 'star',
    specifier: undefined,
    code: 'export * ',
    start: 0,
    end: 23
  }
```