### PR TITLE
fix(findExports): filtering for named exports

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -127,6 +127,6 @@ export function findExports (code: string): ESMExport[] {
   return exports.filter((exp, index, exports) => {
     // Prevent multiple exports of same function, only keep latest iteration of signatures
     const nextExport = exports[index + 1]
-    return !nextExport || exp.type !== nextExport.type || exp.name !== nextExport.name
+    return !nextExport || exp.type !== nextExport.type || !exp.name || exp.name !== nextExport.name
   })
 }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -43,14 +43,13 @@ describe('findExports', () => {
     expect(matches.length).to.eql(3)
   })
 
-  it('works', () => {
+  it('works with multiple named exports', () => {
     const code = `
-import { pauseTracking, resetTracking, isRef, toRaw, isShallow as isShallow$1, isReactive, ReactiveEffect, ref, shallowReadonly, track, reactive, shallowReactive, trigger, isProxy, EffectScope, markRaw, proxyRefs, computed as computed$1, isReadonly } from '@vue/reactivity';
-export { EffectScope, ReactiveEffect, customRef, effect, effectScope, getCurrentScope, isProxy, isReactive, isReadonly, isRef, isShallow, markRaw, onScopeDispose, proxyRefs, reactive, readonly, ref, shallowReactive, shallowReadonly, shallowRef, stop, toRaw, toRef, toRefs, triggerRef, unref } from '@vue/reactivity';
-import { isString, isFunction, isPromise, isArray, NOOP, getGlobalThis, extend, EMPTY_OBJ, toHandlerKey, toNumber, hyphenate, camelize, isOn, hasOwn, isModelListener, hasChanged, remove, isObject, isSet, isMap, isPlainObject, invokeArrayFns, isBuiltInDirective, capitalize, isGloballyWhitelisted, def, isReservedProp, EMPTY_ARR, toRawType, makeMap, NO, normalizeClass, normalizeStyle } from '@vue/shared';
-export { camelize, capitalize, normalizeClass, normalizeProps, normalizeStyle, toDisplayString, toHandlerKey } from '@vue/shared';
+export { foo } from 'foo1';
+export { bar } from 'foo2';
+export { foobar } from 'foo2';
 `
     const matches = findExports(code)
-    expect(matches).to.have.lengthOf(2)
+    expect(matches).to.have.lengthOf(3)
   })
 })

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -15,33 +15,42 @@ describe('findExports', () => {
     'export * as foo from "./other"': { type: 'star', specifier: './other', name: 'foo' }
   }
 
-  describe('findExports', () => {
-    for (const [input, test] of Object.entries(tests)) {
-      it(input.replace(/\n/g, '\\n'), () => {
-        const matches = findExports(input)
-        expect(matches.length).to.equal(1)
-        const match = matches[0]
-        if (test.type) {
-          expect(match.type).to.eql(test.type)
-        }
-        if (test.name) {
-          expect(match.name).to.eql(test.name)
-        }
-        if (test.names) {
-          expect(match.names).to.deep.eql(test.names)
-        }
-        if (test.specifier) {
-          expect(match.specifier).to.eql(test.specifier)
-        }
-      })
-    }
-    it('handles multiple exports', () => {
-      const matches = findExports(`
+  for (const [input, test] of Object.entries(tests)) {
+    it(input.replace(/\n/g, '\\n'), () => {
+      const matches = findExports(input)
+      expect(matches.length).to.equal(1)
+      const match = matches[0]
+      if (test.type) {
+        expect(match.type).to.eql(test.type)
+      }
+      if (test.name) {
+        expect(match.name).to.eql(test.name)
+      }
+      if (test.names) {
+        expect(match.names).to.deep.eql(test.names)
+      }
+      if (test.specifier) {
+        expect(match.specifier).to.eql(test.specifier)
+      }
+    })
+  }
+  it('handles multiple exports', () => {
+    const matches = findExports(`
         export { useTestMe1 } from "@/test/foo1";
         export { useTestMe2 } from "@/test/foo2";
         export { useTestMe3 } from "@/test/foo3";
       `)
-      expect(matches.length).to.eql(3)
-    })
+    expect(matches.length).to.eql(3)
+  })
+
+  it('works', () => {
+    const code = `
+import { pauseTracking, resetTracking, isRef, toRaw, isShallow as isShallow$1, isReactive, ReactiveEffect, ref, shallowReadonly, track, reactive, shallowReactive, trigger, isProxy, EffectScope, markRaw, proxyRefs, computed as computed$1, isReadonly } from '@vue/reactivity';
+export { EffectScope, ReactiveEffect, customRef, effect, effectScope, getCurrentScope, isProxy, isReactive, isReadonly, isRef, isShallow, markRaw, onScopeDispose, proxyRefs, reactive, readonly, ref, shallowReactive, shallowReadonly, shallowRef, stop, toRaw, toRef, toRefs, triggerRef, unref } from '@vue/reactivity';
+import { isString, isFunction, isPromise, isArray, NOOP, getGlobalThis, extend, EMPTY_OBJ, toHandlerKey, toNumber, hyphenate, camelize, isOn, hasOwn, isModelListener, hasChanged, remove, isObject, isSet, isMap, isPlainObject, invokeArrayFns, isBuiltInDirective, capitalize, isGloballyWhitelisted, def, isReservedProp, EMPTY_ARR, toRawType, makeMap, NO, normalizeClass, normalizeStyle } from '@vue/shared';
+export { camelize, capitalize, normalizeClass, normalizeProps, normalizeStyle, toDisplayString, toHandlerKey } from '@vue/shared';
+`
+    const matches = findExports(code)
+    expect(matches).to.have.lengthOf(2)
   })
 })

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,8 +1,8 @@
 import { describe, it, expect } from 'vitest'
-import { findExports } from '../src'
+import { ESMExport, findExports } from '../src'
 
 describe('findExports', () => {
-  const tests = {
+  const tests: Record<string, Partial<ESMExport>> = {
     'export function useA () { return \'a\' }': { name: 'useA', type: 'declaration' },
     'export const useD = () => { return \'d\' }': { name: 'useD', type: 'declaration' },
     'export { useB, _useC as useC }': { names: ['useB', 'useC'], type: 'named' },
@@ -18,19 +18,19 @@ describe('findExports', () => {
   for (const [input, test] of Object.entries(tests)) {
     it(input.replace(/\n/g, '\\n'), () => {
       const matches = findExports(input)
-      expect(matches.length).to.equal(1)
+      expect(matches.length).toEqual(1)
       const match = matches[0]
       if (test.type) {
-        expect(match.type).to.eql(test.type)
+        expect(match.type).toEqual(test.type)
       }
       if (test.name) {
-        expect(match.name).to.eql(test.name)
+        expect(match.name).toEqual(test.name)
       }
       if (test.names) {
-        expect(match.names).to.deep.eql(test.names)
+        expect(match.names).toEqual(test.names)
       }
       if (test.specifier) {
-        expect(match.specifier).to.eql(test.specifier)
+        expect(match.specifier).toEqual(test.specifier)
       }
     })
   }


### PR DESCRIPTION
The filtering introduced in #40 incidentally filtered out named exports like:

```js
[
  { type: 'named', names: ['foo', /* ... */] },
  { type: 'named', names: ['bar', /* ... */] },
]
```

to becomes

```js
[
  { type: 'named', names: ['bar', /* ... */] },
]
```

Due to both of the exports having undefined of the `name` property.

