### PR TITLE
fix(findExports): export with trailing comma

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -99,7 +99,7 @@ export function findExports (code: string): ESMExport[] {
   // Find named exports
   const namedExports = matchAll(EXPORT_NAMED_RE, code, { type: 'named' })
   for (const namedExport of namedExports) {
-    namedExport.names = namedExport.exports.split(/\s*,\s*/g).map(name => name.replace(/^.*?\sas\s/, '').trim())
+    namedExport.names = namedExport.exports.split(/\s*,\s*/g).map(name => name.replace(/^.*?\sas\s/, '').trim()).filter(name => !!name)
   }
 
   // Find export default

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -8,6 +8,7 @@ describe('findExports', () => {
     'export { useB, _useC as useC }': { names: ['useB', 'useC'], type: 'named' },
     'export default foo': { type: 'default', name: 'default', names: ['default'] },
     'export { default } from "./other"': { type: 'default', name: 'default', names: ['default'], specifier: './other' },
+    'export { default , } from "./other"': { type: 'default', name: 'default', names: ['default'], specifier: './other' },
     'export async function foo ()': { type: 'declaration', names: ['foo'] },
     'export const $foo = () => {}': { type: 'declaration', names: ['$foo'] },
     'export { foo as default }': { type: 'default', name: 'default', names: ['default'] },


### PR DESCRIPTION
> fix `findExport` function:
> when handle a export code with trailing comma , EXPORT_NAMED_RE Regex with contain the last comma , which cause 
> genarage a blank name`(name='')` export

it seams easy to resolve this case by add filter `name!==''` to namedExport.names https://github.com/unjs/mlly/blob/b5d0a3fd832f4826ceac9f670ec1990172432b28/src/analyze.ts#L102

* A little confuse about Regex at present , will try to fix this by adjust the EXPORT_NAMED_RE syntax later