### PR TITLE
fix(findExports): get exports with trailing comma

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -56,7 +56,7 @@ export const ESM_STATIC_IMPORT_RE = /(?<=\s|^|;)import\s*(["'\s]*(?<imports>[\w*
 export const DYNAMIC_IMPORT_RE = /import\s*\((?<expression>(?:[^)(]+|\((?:[^)(]+|\([^)(]*\))*\))*)\)/gm
 
 export const EXPORT_DECAL_RE = /\bexport\s+(?<declaration>(async function|function|let|const|var|class))\s+(?<name>[\w$_]+)/g
-const EXPORT_NAMED_RE = /\bexport\s+{(?<exports>[^}]+)}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^"\s](?=\s*")|(?<='\s*)[^']*[^'\s](?=\s*'))\s*["'][^\n]*)?/g
+const EXPORT_NAMED_RE = /\bexport\s+{(?<exports>[^}]+?)(?:[,\s]*)}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^"\s](?=\s*")|(?<='\s*)[^']*[^'\s](?=\s*'))\s*["'][^\n]*)?/g
 const EXPORT_STAR_RE = /\bexport\s*(\*)(\s*as\s+(?<name>[\w$_]+)\s+)?\s*(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^"\s](?=\s*")|(?<='\s*)[^']*[^'\s](?=\s*'))\s*["'][^\n]*)?/g
 const EXPORT_DEFAULT_RE = /\bexport\s+default\s+/g
 
@@ -99,7 +99,7 @@ export function findExports (code: string): ESMExport[] {
   // Find named exports
   const namedExports = matchAll(EXPORT_NAMED_RE, code, { type: 'named' })
   for (const namedExport of namedExports) {
-    namedExport.names = namedExport.exports.split(/\s*,\s*/g).map(name => name.replace(/^.*?\sas\s/, '').trim()).filter(name => !!name)
+    namedExport.names = namedExport.exports.split(/\s*,\s*/g).map(name => name.replace(/^.*?\sas\s/, '').trim())
   }
 
   // Find export default

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -9,6 +9,8 @@ describe('findExports', () => {
     'export default foo': { type: 'default', name: 'default', names: ['default'] },
     'export { default } from "./other"': { type: 'default', name: 'default', names: ['default'], specifier: './other' },
     'export { default , } from "./other"': { type: 'default', name: 'default', names: ['default'], specifier: './other' },
+    'export { useA , } from "./path"': { type: 'named', name: 'useA', names: ['useA'], specifier: './path' },
+    'export { useA , useB  , } from "./path"': { type: 'named', names: ['useA', 'useB'], specifier: './path' },
     'export async function foo ()': { type: 'declaration', names: ['foo'] },
     'export const $foo = () => {}': { type: 'declaration', names: ['$foo'] },
     'export { foo as default }': { type: 'default', name: 'default', names: ['default'] },


### PR DESCRIPTION
# Correct #59 
Adjust EXPORT_NAMED_RE regex not to match the `trailing comma & blank` in export name, so no need to filter !!name after split exports