### PR TITLE
feat: `resolveModuleExportNames` and `findExportNames`

### DIFF
--- a/README.md
+++ b/README.md
@@ -323,17 +323,26 @@ Outputs:
 Same as `findExports` but returns array of export names.
 
 ```js
-import { findExports } from 'mlly'
+import { findExportNames } from 'mlly'
 
 // [ "foo", "bar", "baz", "default" ]
-console.log(findExports(`
+console.log(findExportNames(`
 export const foo = 'bar'
 export { bar, baz }
 export default something
 `))
 ```
 
-##
+## `resolveModuleExportNames`
+
+Resolves module and reads its contents to extract possible export names using static analyzes.
+
+```js
+import { resolveModuleExportNames } from 'mlly'
+
+// ["basename", "dirname", ... ]
+console.log(await resolveModuleExportNames('pathe'))
+```
 
 ## Evaluating Modules
 

--- a/README.md
+++ b/README.md
@@ -320,7 +320,7 @@ Outputs:
 
 ### `findExportNames`
 
-Same as `fineExports` but returns array of export names.
+Same as `findExports` but returns array of export names.
 
 ```js
 import { findExports } from 'mlly'

--- a/README.md
+++ b/README.md
@@ -29,8 +29,6 @@ import { } from 'mlly'
 const { } = require('mlly')
 ```
 
-
-
 ## Resolving ESM modules
 
 Several utilities to make ESM resolution easier:
@@ -286,8 +284,6 @@ const foo = await import('bar')
 
 ### `findExports`
 
-**Note:** API Of this function might be broken in a breaking change for code matcher
-
 ```js
 import { findExports } from 'mlly'
 
@@ -321,6 +317,23 @@ Outputs:
   { type: 'default', code: 'export default ', start: 46, end: 61 }
 ]
 ```
+
+### `findExportNames`
+
+Same as `fineExports` but returns array of export names.
+
+```js
+import { findExports } from 'mlly'
+
+// [ "foo", "bar", "baz", "default" ]
+console.log(findExports(`
+export const foo = 'bar'
+export { bar, baz }
+export default something
+`))
+```
+
+##
 
 ## Evaluating Modules
 

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,5 +1,7 @@
 import { tokenizer } from 'acorn'
 import { matchAll } from './_utils'
+import { resolvePath, ResolveOptions } from './resolve'
+import { loadURL } from './utils'
 
 export interface ESMImport {
   type: 'static' | 'dynamic'
@@ -142,6 +144,17 @@ export function findExports (code: string): ESMExport[] {
     const nextExport = exports[index + 1]
     return !nextExport || exp.type !== nextExport.type || !exp.name || exp.name !== nextExport.name
   })
+}
+
+export function findExportNames (code: string): string[] {
+  return findExports(code).flatMap(exp => exp.names)
+}
+
+export async function resolveModuleExportNames (id: string, opts?: ResolveOptions): Promise<string[]> {
+  const url = await resolvePath(id, opts)
+  const code = await loadURL(url)
+  const exports = findExports(code)
+  return exports.flatMap(exp => exp.names)
 }
 
 // --- Internal ---

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect } from 'vitest'
-import { ESMExport, findExports } from '../src'
+import { ESMExport, findExports, findExportNames, resolveModuleExportNames } from '../src'
 
 describe('findExports', () => {
   const tests: Record<string, Partial<ESMExport>> = {
@@ -113,5 +113,45 @@ describe('findExports', () => {
     }, 'export { bar } from \'foo2\'; \n export { foobar } from \'foo2\';')
     const matches = findExports(code)
     expect(matches).to.have.lengthOf(2)
+  })
+})
+
+describe('fineExportNames', () => {
+  it('findExportNames', () => {
+    expect(findExportNames(`
+    export const foo = 'bar'
+    export { bar, baz }
+    export default something
+    `)).toMatchInlineSnapshot(`
+      [
+        "foo",
+        "bar",
+        "baz",
+        "default",
+      ]
+    `)
+  })
+})
+
+describe('resolveModuleExportNames', () => {
+  it('resolveModuleExportNames', async () => {
+    expect(await resolveModuleExportNames('pathe')).toMatchInlineSnapshot(`
+      [
+        "basename",
+        "delimiter",
+        "dirname",
+        "extname",
+        "format",
+        "isAbsolute",
+        "join",
+        "normalize",
+        "normalizeString",
+        "parse",
+        "relative",
+        "resolve",
+        "sep",
+        "toNamespacedPath",
+      ]
+    `)
   })
 })


### PR DESCRIPTION
Expose `fineExportNames` as a shortcut for `findExports` that only returns export names.

Add new `resolveModuleExportNames` that resolves and reads a module and lists it's available exports using static analayzes.

Note: I didn't include `resolveModuleExports` with additional loc data since seems not useful. But name uses `Names` suffix so we have space to introduce it later.