### PR TITLE
fix: revert using acorn tokenizer

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,6 @@
     "test": "pnpm lint && vitest run"
   },
   "dependencies": {
-    "acorn": "^8.8.0",
     "pathe": "^0.3.3",
     "pkg-types": "^0.3.3"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -3,7 +3,6 @@ lockfileVersion: 5.4
 specifiers:
   '@nuxtjs/eslint-config-typescript': latest
   '@types/node': latest
-  acorn: ^8.8.0
   c8: latest
   eslint: latest
   jiti: latest
@@ -14,7 +13,6 @@ specifiers:
   vitest: latest
 
 dependencies:
-  acorn: 8.8.0
   pathe: 0.3.3
   pkg-types: 0.3.3
 
@@ -642,6 +640,7 @@ packages:
     resolution: {integrity: sha512-QOxyigPVrpZ2GXT+PFyZTl6TtOFc5egxHIP9IlQ+RbupQuX4RkT/Bee4/kQuC02Xkzg84JcT7oLYtDIQxp+v7w==}
     engines: {node: '>=0.4.0'}
     hasBin: true
+    dev: true
 
   /add-stream/1.0.0:
     resolution: {integrity: sha512-qQLMr+8o0WC4FZGQTcJiKBVC59JylcPSrTtk6usvmIDFUOCKegapy1VHQwRbFMOFyb/inzUVqHs+eMYKDM1YeQ==}
@@ -906,7 +905,7 @@ packages:
     dev: true
 
   /concat-map/0.0.1:
-    resolution: {integrity: sha512-/Srv4dswyQNBfohGpz9o6Yb3Gz3SrUDqBH5rTuhGR7ahtlbYKnVxw2bCFMRljaA7EXHaXZ8wsHdodFvbkhKmqg==}
+    resolution: {integrity: sha1-2Klr13/Wjfd5OnMDajug1UBdR3s=}
     dev: true
 
   /concat-stream/2.0.0:

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -50,10 +50,10 @@ describe('findExports', () => {
 
   it('works with multiple named exports', () => {
     const code = `
-  export { foo } from 'foo1';
-  export { bar } from 'foo2';
-  export { foobar } from 'foo2';
-  `
+      export { foo } from 'foo1';
+      export { bar } from 'foo2';
+      export { foobar } from 'foo2';
+    `
     const matches = findExports(code)
     expect(matches).to.have.lengthOf(3)
   })
@@ -61,31 +61,31 @@ describe('findExports', () => {
   // TODO: https://github.com/unjs/mlly/issues/64
   it.todo('the commented out export should be filtered out', () => {
     const code = `
-        // export { foo } from 'foo1';
-        // exports default 'foo';
-        // export { useB, _useC as useC };
-        // export function useA () { return 'a' }
-        // export { default } from "./other"
-        // export async function foo () {}
-        // export { foo as default }
-        //export * from "./other"
-        //export * as foo from "./other"
+      // export { foo } from 'foo1';
+      // exports default 'foo';
+      // export { useB, _useC as useC };
+      // export function useA () { return 'a' }
+      // export { default } from "./other"
+      // export async function foo () {}
+      // export { foo as default }
+      //export * from "./other"
+      //export * as foo from "./other"
 
-        /**
-         * export const a = 123
-         * export { foo } from 'foo1';
-         * exports default 'foo'
-         * export function useA () { return 'a' }
-         * export { useB, _useC as useC };
-         *export { default } from "./other"
-         *export async function foo () {}
-         * export { foo as default }
-         * export * from "./other"
-         export * as foo from "./other"
-         */
-        export { bar } from 'foo2';
-        export { foobar } from 'foo2';
-      `
+      /**
+       * export const a = 123
+       * export { foo } from 'foo1';
+       * exports default 'foo'
+       * export function useA () { return 'a' }
+       * export { useB, _useC as useC };
+       *export { default } from "./other"
+        *export async function foo () {}
+        * export { foo as default }
+        * export * from "./other"
+        export * as foo from "./other"
+        */
+      export { bar } from 'foo2';
+      export { foobar } from 'foo2';
+    `
     const matches = findExports(code)
     expect(matches).to.have.lengthOf(2)
   })
@@ -123,9 +123,9 @@ describe('findExports', () => {
 describe('fineExportNames', () => {
   it('findExportNames', () => {
     expect(findExportNames(`
-    export const foo = 'bar'
-    export { bar, baz }
-    export default something
+      export const foo = 'bar'
+      export { bar, baz }
+      export default something
     `)).toMatchInlineSnapshot(`
       [
         "foo",

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -41,19 +41,19 @@ describe('findExports', () => {
   }
   it('handles multiple exports', () => {
     const matches = findExports(`
-        export { useTestMe1 } from "@/test/foo1";
-        export { useTestMe2 } from "@/test/foo2";
-        export { useTestMe3 } from "@/test/foo3";
-      `)
+      export { useTestMe1 } from "@/test/foo1";
+      export { useTestMe2 } from "@/test/foo2";
+      export { useTestMe3 } from "@/test/foo3";
+    `)
     expect(matches.length).to.eql(3)
   })
 
   it('works with multiple named exports', () => {
     const code = `
-export { foo } from 'foo1';
-export { bar } from 'foo2';
-export { foobar } from 'foo2';
-`
+  export { foo } from 'foo1';
+  export { bar } from 'foo2';
+  export { foobar } from 'foo2';
+  `
     const matches = findExports(code)
     expect(matches).to.have.lengthOf(3)
   })

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -13,6 +13,8 @@ describe('findExports', () => {
     'export { useA , useB  , } from "./path"': { type: 'named', names: ['useA', 'useB'], specifier: './path' },
     'export async function foo ()': { type: 'declaration', names: ['foo'] },
     'export const $foo = () => {}': { type: 'declaration', names: ['$foo'] },
+    // eslint-disable-next-line
+    'const a = `<div${JSON.stringify({ class: 42 })}>`;\nexport const $foo = () => {}': { type: 'declaration', names: ['$foo'] },
     'export { foo as default }': { type: 'default', name: 'default', names: ['default'] },
     'export * from "./other"': { type: 'star', specifier: './other' },
     'export * as foo from "./other"': { type: 'star', specifier: './other', name: 'foo' }
@@ -39,24 +41,25 @@ describe('findExports', () => {
   }
   it('handles multiple exports', () => {
     const matches = findExports(`
-          export { useTestMe1 } from "@/test/foo1";
-          export { useTestMe2 } from "@/test/foo2";
-          export { useTestMe3 } from "@/test/foo3";
-        `)
+        export { useTestMe1 } from "@/test/foo1";
+        export { useTestMe2 } from "@/test/foo2";
+        export { useTestMe3 } from "@/test/foo3";
+      `)
     expect(matches.length).to.eql(3)
   })
 
   it('works with multiple named exports', () => {
     const code = `
-  export { foo } from 'foo1';
-  export { bar } from 'foo2';
-  export { foobar } from 'foo2';
-  `
+export { foo } from 'foo1';
+export { bar } from 'foo2';
+export { foobar } from 'foo2';
+`
     const matches = findExports(code)
     expect(matches).to.have.lengthOf(3)
   })
 
-  it('the commented out export should be filtered out', () => {
+  // TODO: https://github.com/unjs/mlly/issues/64
+  it.todo('the commented out export should be filtered out', () => {
     const code = `
         // export { foo } from 'foo1';
         // exports default 'foo';
@@ -86,7 +89,8 @@ describe('findExports', () => {
     const matches = findExports(code)
     expect(matches).to.have.lengthOf(2)
   })
-  it('export in string', () => {
+  // TODO: https://github.com/unjs/mlly/issues/64
+  it.todo('export in string', () => {
     const tests: string[] = [
       'export function useA () { return \'a\' }',
       'export const useD = () => { return \'d\' }',


### PR DESCRIPTION
This reverts commit 7039f54277b1791e99b4f625198dfba2dbf6fbe6.

resolves https://github.com/unjs/mlly/issues/64.

If this is an acceptable hotfix I'll reopen the issue the previous commit solved and we can look to reenable the feature, perhaps in a different way.This reverts commit 7039f54.