### PR TITLE
fix(resolve): always try to resolve url as dir too

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -61,6 +61,8 @@ function _resolve (id: string, opts: ResolveOptions = {}): string {
     if (url.protocol === 'file:') {
       urls.push(new URL('./', url))
       urls.push(new URL(joinURL(url.pathname, '_index.js'), url))
+      // TODO: Remove in next major version seems not necessary
+      urls.push(new URL('./node_modules', url))
     }
   }
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -61,12 +61,10 @@ function _resolve (id: string, opts: ResolveOptions = {}): string {
     if (url.protocol === 'file:') {
       if (!url.pathname.match(/[^/]+\.[^/.]+$/)) {
         // URL does not ends with extension. It is probably a directory.
-        url = new URL(url)
-        url.pathname = joinURL(url.pathname, '_index.js')
+        url = new URL(joinURL(url.pathname, '_index.js'), url)
       }
       urls.push(new URL('./', url))
-      // TODO: Remove in next major version seems not necessary
-      urls.push(new URL('./node_modules', url))
+      urls.push(new URL(joinURL(url.pathname, 'node_modules'), url))
     }
   }
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -60,6 +60,7 @@ function _resolve (id: string, opts: ResolveOptions = {}): string {
   for (const url of _urls) {
     if (url.protocol === 'file:') {
       urls.push(new URL('./', url))
+      // If url is directory
       urls.push(new URL(joinURL(url.pathname, '_index.js'), url))
       // TODO: Remove in next major version seems not necessary
       urls.push(new URL('./node_modules', url))

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -57,14 +57,10 @@ function _resolve (id: string, opts: ResolveOptions = {}): string {
     _urls.push(DEFAULT_URL)
   }
   const urls = [..._urls]
-  for (let url of _urls) {
+  for (const url of _urls) {
     if (url.protocol === 'file:') {
-      if (!url.pathname.match(/[^/]+\.[^/.]+$/)) {
-        // URL does not ends with extension. It is probably a directory.
-        url = new URL(joinURL(url.pathname, '_index.js'), url)
-      }
       urls.push(new URL('./', url))
-      urls.push(new URL(joinURL(url.pathname, 'node_modules'), url))
+      urls.push(new URL(joinURL(url.pathname, '_index.js'), url))
     }
   }
 


### PR DESCRIPTION
We are sometimes wrongly detecting directories as files. This PR updates behaviour not to distinguish between them, but assume either might be true.