### PR TITLE
fix: ignore `type` imports and exports

### DIFF
--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -146,6 +146,17 @@ export default function useMain() {}
     expect(matches1[0].name).toEqual("default");
     expect(matches2).toEqual(matches1);
   });
+
+  it("ignore export type", () => {
+    const code = `
+export { type AType, type B as BType, foo } from 'foo'
+`;
+    const matches = findExports(code);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toHaveLength(1);
+    expect(matches[0].names[0]).toEqual("foo");
+    expect(matches[0].name).toEqual("foo");
+  });
 });
 
 describe("fineExportNames", () => {

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -92,6 +92,11 @@ staticTests[`import {
   namedImports: { Component: "Component" }
 };
 
+staticTests["import { foo, type Foo } from \"foo\""] = {
+  specifier: "foo",
+  namedImports: { foo: "foo" }
+};
+
 // -- Dynamic import --
 const dynamicTests = {
   "const { test, /* here */, another, } = await import ( \"module-name\" );": {


### PR DESCRIPTION
Fix the issue https://github.com/unjs/unbuild/issues/136 are use unbuild stub mode, when entry file content `export type XXX`