### PR TITLE
fix(resolve): stop searching when module is resolved

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,4 @@
 node_modules
+!test/fixture/package/node_modules
 dist
 *.log

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -104,6 +104,9 @@ function _resolve(id: string, options: ResolveOptions = {}): string {
         break;
       }
     }
+    if (resolved) {
+      break;
+    }
   }
 
   // Throw error if not found

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -280,6 +280,20 @@ describe("resolveModuleExportNames", () => {
     `);
   });
 
+  it("star exports with package", async () => {
+    expect(
+      await resolveModuleExportNames(
+        new URL("fixture/package/exports.mjs", import.meta.url).toString()
+      )
+    ).toMatchInlineSnapshot(`
+      [
+        "StaticRouter",
+        "unstable_StaticRouterProvider",
+        "unstable_createStaticRouter",
+      ]
+    `);
+  });
+
   it("multiple inline", () => {
     const code = `
 export { foo } from 'foo1';export { bar } from 'foo2';export * as foobar from 'foo2';

--- a/test/fixture/package/exports.mjs
+++ b/test/fixture/package/exports.mjs
@@ -1,0 +1,1 @@
+export * from "react-router-dom/server";

--- a/test/fixture/package/node_modules/react-router-dom/package.json
+++ b/test/fixture/package/node_modules/react-router-dom/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "react-router-dom",
+  "version": "6.4.3",
+  "sideEffects": false,
+  "main": "./dist/main.js",
+  "module": "./dist/index.js",
+  "files": [
+    "dist/",
+    "server.js",
+    "server.mjs"
+  ]
+}

--- a/test/fixture/package/node_modules/react-router-dom/server.js
+++ b/test/fixture/package/node_modules/react-router-dom/server.js
@@ -1,0 +1,13 @@
+"use strict";
+
+Object.defineProperty(exports, "__esModule", { value: true });
+
+function StaticRouter() {}
+
+function unstable_StaticRouterProvider() {}
+
+function unstable_createStaticRouter() {}
+
+exports.StaticRouter = StaticRouter;
+exports.unstable_StaticRouterProvider = unstable_StaticRouterProvider;
+exports.unstable_createStaticRouter = unstable_createStaticRouter;

--- a/test/fixture/package/node_modules/react-router-dom/server.mjs
+++ b/test/fixture/package/node_modules/react-router-dom/server.mjs
@@ -1,0 +1,7 @@
+function StaticRouter() {}
+
+function unstable_StaticRouterProvider() {}
+
+function unstable_createStaticRouter() {}
+
+export { StaticRouter, unstable_StaticRouterProvider, unstable_createStaticRouter };

--- a/test/fixture/package/package.json
+++ b/test/fixture/package/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "package",
+  "private": true,
+  "dependencies": {}
+}


### PR DESCRIPTION
This prevents `resolve` and functions relying on it (like `resolveModuleExportNames`) from crashing with

```
Error: ENOTDIR: not a directory, open '/___/mlly/test/fixture/package/exports.mjs/package.json'
```

This happens when trying to resolve the exports of `react-router-dom/server`. I've added a fixture that is a stripped down version of `react-router-dom@6.4.3`.
You can see the error when running the test without the fix.