### PR TITLE
fix(sanitizeURIComponent): sanitize url escaping

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -14,7 +14,9 @@ export function fileURLToPath(id: string): string {
 const INVALID_CHAR_RE = /[\u0000-\u001F"#$&*+,/:;<=>?@[\]^`{|}\u007F]+/g;
 
 export function sanitizeURIComponent(name = "", replacement = "_"): string {
-  return name.replace(INVALID_CHAR_RE, replacement);
+  return name
+    .replace(INVALID_CHAR_RE, replacement)
+    .replace(/%../g, replacement);
 }
 
 export function sanitizeFilePath(filePath = "") {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -30,7 +30,8 @@ describe("sanitizeFilePath", () => {
     "/te#st/[].jsx": "/te_st/_.jsx",
     '\0a?b*c:d\u007Fe<f>g#h"i{j}k|l^m[n]o`p.jsx':
       "_a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p.jsx",
-    "Foo.vue?vue&type=script&setup=true&generic=T%20extends%20any%2C%20O%20extends%20T%3CZ%7Ca%3E&lang": "Foo.vue_vue_type_script_setup_true_generic_T_extends_any__O_extends_T_Z_a__lang",
+    "Foo.vue?vue&type=script&setup=true&generic=T%20extends%20any%2C%20O%20extends%20T%3CZ%7Ca%3E&lang":
+      "Foo.vue_vue_type_script_setup_true_generic_T_extends_any__O_extends_T_Z_a__lang",
     "": "",
   };
   for (const id in cases) {

--- a/test/utils.test.ts
+++ b/test/utils.test.ts
@@ -30,6 +30,7 @@ describe("sanitizeFilePath", () => {
     "/te#st/[].jsx": "/te_st/_.jsx",
     '\0a?b*c:d\u007Fe<f>g#h"i{j}k|l^m[n]o`p.jsx':
       "_a_b_c_d_e_f_g_h_i_j_k_l_m_n_o_p.jsx",
+    "Foo.vue?vue&type=script&setup=true&generic=T%20extends%20any%2C%20O%20extends%20T%3CZ%7Ca%3E&lang": "Foo.vue_vue_type_script_setup_true_generic_T_extends_any__O_extends_T_Z_a__lang",
     "": "",
   };
   for (const id in cases) {


### PR DESCRIPTION
When you compose your Vue component like:

```html
<script setup lang="ts" generic="T extends any, O extends any">
// ...
</script>
```

its id will be served as `Foo.vue?vue&type=script&setup=true&generic=T%20extends%20any%2C%20O%20extends%20T%3CZ%7Ca%3E&lang`

in which `sanitizeURIComponent` is not able to sanitize `%20` making it writes to filename. In that sense, breaking the production build of Nuxt as the browser will interop the URL as a space (404).

& further discussion: #138