### PR TITLE
feat: add support for finding type exports

### DIFF
--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -103,6 +103,44 @@ describe("findExports", () => {
     expect(matches.length).to.eql(3);
   });
 
+  it("finds type exports", () => {
+    const matches = findExports(
+      `
+          export type { Foo } from "./foo";
+          export type { Bar } from "./bar";
+        `,
+      { includeTypeExports: true }
+    );
+    expect(matches).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "export type { Foo } from \\"./foo\\"",
+          "end": 43,
+          "exports": " Foo",
+          "name": "Foo",
+          "names": [
+            "Foo",
+          ],
+          "specifier": "./foo",
+          "start": 11,
+          "type": "named-type",
+        },
+        {
+          "code": "export type { Bar } from \\"./bar\\"",
+          "end": 87,
+          "exports": " Bar",
+          "name": "Bar",
+          "names": [
+            "Bar",
+          ],
+          "specifier": "./bar",
+          "start": 55,
+          "type": "named-type",
+        },
+      ]
+    `);
+  });
+
   it("works with multiple named exports", () => {
     const code = `
   export { foo } from 'foo1';
@@ -212,7 +250,7 @@ export { type AType, type B as BType, foo } from 'foo'
   });
 });
 
-describe("fineExportNames", () => {
+describe("findExportNames", () => {
   it("findExportNames", () => {
     expect(
       findExportNames(`


### PR DESCRIPTION
### 🔗 Linked issue



### ❓ Type of change
- [ ] 📖 Documentation (updates to the documentation or readme)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

This adds support for finding type exports which might be useful for type auto-import downstream in unimport (https://github.com/unjs/unimport/pull/218) - as well as in https://github.com/unjs/mkdist (https://github.com/unjs/mkdist/pull/134).

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
