### PR TITLE
fix: fix `resolvePath` return type

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -6,7 +6,10 @@ export function normalizeSlash(string_) {
   return string_.replace(/\\/g, "/");
 }
 
-export function pcall(function_, ...arguments_) {
+export function pcall<TFn extends (...args: any[]) => any>(
+  function_: TFn,
+  ...arguments_: Parameters<TFn>
+): Promise<ReturnType<TFn>> {
   try {
     return Promise.resolve(function_(...arguments_)).catch((error) =>
       perr(error)

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -124,11 +124,11 @@ function _resolve(id: string, options: ResolveOptions = {}): string {
   return pathToFileURL(realPath).toString();
 }
 
-export function resolveSync(id: string, options?: ResolveOptions): string {
+export function resolveSync(id: string, options?: ResolveOptions) {
   return _resolve(id, options);
 }
 
-export function resolve(id: string, options?: ResolveOptions): Promise<string> {
+export function resolve(id: string, options?: ResolveOptions) {
   return pcall(resolveSync, id, options);
 }
 

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -124,19 +124,22 @@ function _resolve(id: string, options: ResolveOptions = {}): string {
   return pathToFileURL(realPath).toString();
 }
 
-export function resolveSync(id: string, options?: ResolveOptions) {
+export function resolveSync(id: string, options?: ResolveOptions): string {
   return _resolve(id, options);
 }
 
-export function resolve(id: string, options?: ResolveOptions) {
+export function resolve(id: string, options?: ResolveOptions): Promise<string> {
   return pcall(resolveSync, id, options);
 }
 
-export function resolvePathSync(id: string, options?: ResolveOptions) {
+export function resolvePathSync(id: string, options?: ResolveOptions): string {
   return fileURLToPath(resolveSync(id, options));
 }
 
-export function resolvePath(id: string, options?: ResolveOptions) {
+export function resolvePath(
+  id: string,
+  options?: ResolveOptions
+): Promise<string> {
   return pcall(resolvePathSync, id, options);
 }
 


### PR DESCRIPTION
`resolvePath` return type is being lost when `resolvePathSync` is passed to `pcall` (Promise\<any\> instead of Promise\<string\>).

`resolve` has the same issue but its return type was being cast from Promise\<any\> to Promise\<string\> via the function signature. instead of casting any I updated `pcall`'s types to reflect what is happening which fixes `resolvePath` types to Promise\<string\>