### PR TITLE
feat(findExports): extract name of default exports

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -81,7 +81,7 @@ const EXPORT_NAMED_DESTRUCT =
 const EXPORT_STAR_RE =
   /\bexport\s*(\*)(\s*as\s+(?<name>[\w$]+)\s+)?\s*(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_DEFAULT_RE =
-  /\bexport\s+default\s+(async function|function|class|true|false|(\W\D)|\d)|\bexport\s+default\s+(?!async function|function|class|true|false|\W|\d)(?<defaultName>\w+)/g;
+  /\bexport\s+default\s+(async function|function|class|true|false|\W|\d)|\bexport\s+default\s+(?<defaultName>.*)/g;
 const TYPE_RE = /^\s*?type\s/;
 
 export function findStaticImports(code: string): StaticImport[] {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -34,13 +34,12 @@ export interface TypeImport extends Omit<ESMImport, "type"> {
 }
 
 export interface ESMExport {
-  _type?: "declaration" | "named" | "default" | "namedDefault" | "star";
-  type: "declaration" | "named" | "default" | "namedDefault" | "star";
+  _type?: "declaration" | "named" | "default" | "star";
+  type: "declaration" | "named" | "default" | "star";
   code: string;
   start: number;
   end: number;
   name?: string;
-  defaultName?: string;
   names: string[];
   specifier?: string;
 }
@@ -185,7 +184,6 @@ export function findExports(code: string): ESMExport[] {
     code,
     { type: "named" },
   );
-
   for (const namedExport of destructuredExports) {
     // @ts-expect-error groups
     namedExport.exports = namedExport.exports1 || namedExport.exports2;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -22,7 +22,7 @@ describe("findExports", () => {
       type: "named",
     },
     "export default foo": {
-      type: "namedDefault",
+      type: "default",
       name: "default",
       names: ["default"],
     },
@@ -53,6 +53,12 @@ describe("findExports", () => {
     "export async function* foo ()": { type: "declaration", names: ["foo"] },
     "export async function *foo ()": { type: "declaration", names: ["foo"] },
     "export const $foo = () => {}": { type: "declaration", names: ["$foo"] },
+    "export default something": {
+      type: "default",
+      name: "default",
+      defaultName: "something",
+      names: ["default"],
+    },
     "export { foo as default }": {
       type: "default",
       name: "default",
@@ -94,6 +100,9 @@ describe("findExports", () => {
       }
       if (test.specifier) {
         expect(match.specifier).toEqual(test.specifier);
+      }
+      if (test.defaultName) {
+        expect(match.defaultName).toEqual(test.defaultName);
       }
     });
   }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -22,7 +22,7 @@ describe("findExports", () => {
       type: "named",
     },
     "export default foo": {
-      type: "default",
+      type: "namedDefault",
       name: "default",
       names: ["default"],
     },


### PR DESCRIPTION
Hi!

I am using `unplugin-auto-import` which rely on `unimport` which using this package `findExports` method. And found an edge case when it extract `export default`. The `unplugin-auto-import` can prevent using filename except when we use `export default`. In that case it will always looking for the file name and use it, but for example I use named default export like this:

`exampleStore.ts`:
```ts
const useExampleStore = defineStore({});
export default useExampleStore;
```
In the current version the `findExports` method it will always return the filename (exampleStore). In my case I want to get the name from the default (useExampleStore).

For this 
- I update the `ESMExport` interface with a new `namedDefault` in type.
- I create a new regex for named default export and also update the `EXPORT_DEFAULT_RE`. I update the basic one to prevent duplication in the final exports. (I am not the best with regex so I think it can be written better but it works with every test without duplication).
- Write the search in the `findExports` method and add it to the `exports` array