### PR TITLE
fix(isValidNodeImport): detect invalid cjs modules

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -94,5 +94,5 @@ export async function isValidNodeImport(
     (await fsp.readFile(resolvedPath, "utf8").catch(() => {})) ||
     "";
 
-  return hasCJSSyntax(code) || !hasESMSyntax(code);
+  return !hasESMSyntax(code);
 }

--- a/test/fixture/imports/js-cjs/index.js
+++ b/test/fixture/imports/js-cjs/index.js
@@ -1,2 +1,4 @@
 // eslint-disable-next-line unicorn/prefer-module
 module.exports = "js-cjs";
+
+console.log(import("node:fs"));

--- a/test/fixture/imports/mixed/index.js
+++ b/test/fixture/imports/mixed/index.js
@@ -1,0 +1,12 @@
+/* eslint-disable unicorn/prefer-module */
+export const isCrtAvailable = () => {
+  try {
+    if (
+      typeof require === "function" &&
+      typeof module !== "undefined" &&
+      require("aws-crt")
+    ) {
+      return ["md/crt-avail"];
+    }
+  } catch {}
+};

--- a/test/fixture/imports/mixed/package.json
+++ b/test/fixture/imports/mixed/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "mixed",
+  "version": "1.0.0",
+  "main": "index.cjs"
+}

--- a/test/syntax.test.ts
+++ b/test/syntax.test.ts
@@ -110,6 +110,7 @@ const nodeImportTests = {
   [join(import.meta.url, "../fixture/imports/js-esm")]: false,
   [join(import.meta.url, "../fixture/imports/js-esm/es/index.mjs")]: true,
   [join(import.meta.url, "../fixture/imports/js-esm/es/index.js")]: false,
+  [join(import.meta.url, "../fixture/imports/mixed")]: false,
 };
 
 describe("isValidNodeImport", () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Resolves #186

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

We check for valid ESM modules to either use `.mjs` entries or `type: "module"` (this could later be improved to double check syntax on ESM too)

But when detecting valid CJS entries, we have to make sure there is no mixed syntax before validating module.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
