### PR TITLE
fix: strip comment for syntax detection

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -10,13 +10,13 @@ const ESM_RE =
 const BUILTIN_EXTENSIONS = new Set([".mjs", ".cjs", ".node", ".wasm"]);
 
 export function hasESMSyntax(code: string): boolean {
-  return ESM_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ''));
+  return ESM_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ""));
 }
 
 const CJS_RE =
   /([\s;]|^)(module.exports\b|exports\.\w|require\s*\(|global\.\w)/m;
 export function hasCJSSyntax(code: string): boolean {
-  return CJS_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ''));
+  return CJS_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ""));
 }
 
 export function detectSyntax(code: string) {

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -10,13 +10,13 @@ const ESM_RE =
 const BUILTIN_EXTENSIONS = new Set([".mjs", ".cjs", ".node", ".wasm"]);
 
 export function hasESMSyntax(code: string): boolean {
-  return ESM_RE.test(code);
+  return ESM_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ''));
 }
 
 const CJS_RE =
   /([\s;]|^)(module.exports\b|exports\.\w|require\s*\(|global\.\w)/m;
 export function hasCJSSyntax(code: string): boolean {
-  return CJS_RE.test(code);
+  return CJS_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ''));
 }
 
 export function detectSyntax(code: string) {

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -7,16 +7,19 @@ import { isNodeBuiltin, getProtocol } from "./utils";
 const ESM_RE =
   /([\s;]|^)(import[\s\w*,{}]*from|import\s*["'*{]|export\b\s*(?:[*{]|default|class|type|function|const|var|let|async function)|import\.meta\b)/m;
 
+const CJS_RE =
+  /([\s;]|^)(module.exports\b|exports\.\w|require\s*\(|global\.\w)/m;
+
+const COMMENT_RE = /\/\*.+?\*\/|\/\/.*(?=[nr])/g;
+
 const BUILTIN_EXTENSIONS = new Set([".mjs", ".cjs", ".node", ".wasm"]);
 
 export function hasESMSyntax(code: string): boolean {
-  return ESM_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ""));
+  return ESM_RE.test(code.replace(COMMENT_RE, ""));
 }
 
-const CJS_RE =
-  /([\s;]|^)(module.exports\b|exports\.\w|require\s*\(|global\.\w)/m;
 export function hasCJSSyntax(code: string): boolean {
-  return CJS_RE.test(code.replace(/\/\*.+?\*\/|\/\/.*(?=[nr])/g, ""));
+  return CJS_RE.test(code.replace(COMMENT_RE, ""));
 }
 
 export function detectSyntax(code: string) {

--- a/test/syntax.test.ts
+++ b/test/syntax.test.ts
@@ -82,7 +82,8 @@ const staticTests = {
     isMixed: false,
   },
   "const a={};": { hasESM: false, hasCJS: false, isMixed: false },
-  "// They're exposed using \"export import\" so that types are passed along as expected\nmodule.exports={};": { hasESM: false, hasCJS: true , isMixed: false }
+  '// They\'re exposed using "export import" so that types are passed along as expected\nmodule.exports={};':
+    { hasESM: false, hasCJS: true, isMixed: false },
 };
 
 describe("detectSyntax", () => {

--- a/test/syntax.test.ts
+++ b/test/syntax.test.ts
@@ -82,6 +82,7 @@ const staticTests = {
     isMixed: false,
   },
   "const a={};": { hasESM: false, hasCJS: false, isMixed: false },
+  "// They're exposed using \"export import\" so that types are passed along as expected\nmodule.exports={};": { hasESM: false, hasCJS: true , isMixed: false }
 };
 
 describe("detectSyntax", () => {


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue
resolve #195 
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
hi :wave: this PR fix the syntax detection by removing comments before testing the code string.

There's another solution, much safer but not the best perfomance wise. It's to use an AST combined with magic-string
<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
