### PR TITLE
feat: make `stripComments` optional for syntax detection

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -14,17 +14,35 @@ const COMMENT_RE = /\/\*.+?\*\/|\/\/.*(?=[nr])/g;
 
 const BUILTIN_EXTENSIONS = new Set([".mjs", ".cjs", ".node", ".wasm"]);
 
-export function hasESMSyntax(code: string): boolean {
-  return ESM_RE.test(code.replace(COMMENT_RE, ""));
+export type DetectSyntaxOptions = { stripComments?: boolean };
+
+export function hasESMSyntax(
+  code: string,
+  opts: DetectSyntaxOptions = {},
+): boolean {
+  if (opts.stripComments) {
+    code = code.replace(COMMENT_RE, "");
+  }
+  return ESM_RE.test(code);
 }
 
-export function hasCJSSyntax(code: string): boolean {
-  return CJS_RE.test(code.replace(COMMENT_RE, ""));
+export function hasCJSSyntax(
+  code: string,
+  opts: DetectSyntaxOptions = {},
+): boolean {
+  if (opts.stripComments) {
+    code = code.replace(COMMENT_RE, "");
+  }
+  return CJS_RE.test(code);
 }
 
-export function detectSyntax(code: string) {
-  const hasESM = hasESMSyntax(code);
-  const hasCJS = hasCJSSyntax(code);
+export function detectSyntax(code: string, opts: DetectSyntaxOptions = {}) {
+  if (opts.stripComments) {
+    code = code.replace(COMMENT_RE, "");
+  }
+  // We strip comments once hence not passing opts down to hasESMSyntax and hasCJSSyntax
+  const hasESM = hasESMSyntax(code, {});
+  const hasCJS = hasCJSSyntax(code, {});
 
   return {
     hasESM,

--- a/test/syntax.test.ts
+++ b/test/syntax.test.ts
@@ -61,6 +61,11 @@ const staticTests = {
     isMixed: false,
   },
   "export class": { hasESM: true, hasCJS: false, isMixed: false },
+  "const start = '/* ';import foo from 'bar';const end = ' */'": {
+    hasESM: true,
+    hasCJS: false,
+    isMixed: false,
+  },
   // CJS
   "exports.c={}": { hasESM: false, hasCJS: true, isMixed: false },
   "const b=true;module.exports={b};": {
@@ -82,6 +87,9 @@ const staticTests = {
     isMixed: false,
   },
   "const a={};": { hasESM: false, hasCJS: false, isMixed: false },
+};
+
+const staticTestsWithComments = {
   '// They\'re exposed using "export import" so that types are passed along as expected\nmodule.exports={};':
     { hasESM: false, hasCJS: true, isMixed: false },
 };
@@ -90,6 +98,16 @@ describe("detectSyntax", () => {
   for (const [input, result] of Object.entries(staticTests)) {
     it(input, () => {
       expect(detectSyntax(input)).to.deep.equal(result);
+    });
+  }
+});
+
+describe("detectSyntax (with comment)", () => {
+  for (const [input, result] of Object.entries(staticTestsWithComments)) {
+    it(input, () => {
+      expect(detectSyntax(input, { stripComments: true })).to.deep.equal(
+        result,
+      );
     });
   }
 });


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

Complementary to #196 to avoid regressions

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Striping comments with regex is tricky. (see #56, #155 and added test in this PR -- thanks @danielroe for idea in https://github.com/unjs/mlly/pull/155#discussion_r1121596789!)

This PR makes stripping comments for syntax detection utils so users can opt-in.

In the future (maybe major versions) we might migrate to a native parser.

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
