### PR TITLE
feat: add declaration type in ESMExport

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -36,6 +36,7 @@ export interface TypeImport extends Omit<ESMImport, "type"> {
 export interface ESMExport {
   _type?: "declaration" | "named" | "default" | "star";
   type: "declaration" | "named" | "default" | "star";
+  declarationType?: "interface" | "type" | "enum" | "const" | "function";
   code: string;
   start: number;
   end: number;
@@ -61,6 +62,8 @@ export interface NamedExport extends ESMExport {
 export interface DefaultExport extends ESMExport {
   type: "default";
 }
+
+export const DECLARATION_TYPES: ESMExport['declarationType'][] = ['interface', 'type', 'enum', 'const', 'function']
 
 export const ESM_STATIC_IMPORT_RE =
   /(?<=\s|^|;|\})import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu;
@@ -305,7 +308,7 @@ export function findTypeExports(code: string): ESMExport[] {
   );
 }
 
-function normalizeExports(exports: ESMExport[]) {
+function normalizeExports(exports: (ESMExport & { declaration?: string })[]) {
   for (const exp of exports) {
     if (!exp.name && exp.names && exp.names.length === 1) {
       exp.name = exp.names[0];
@@ -316,6 +319,9 @@ function normalizeExports(exports: ESMExport[]) {
     }
     if (!exp.names && exp.name) {
       exp.names = [exp.name];
+    }
+    if (exp.type === 'declaration') {
+      exp.declarationType = DECLARATION_TYPES.find(d => exp.declaration.includes(d))
     }
   }
   return exports;

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -36,7 +36,15 @@ export interface TypeImport extends Omit<ESMImport, "type"> {
 export interface ESMExport {
   _type?: "declaration" | "named" | "default" | "star";
   type: "declaration" | "named" | "default" | "star";
-  declarationType?: "interface" | "type" | "enum" | "const" | "function";
+  declarationType?:
+    | "let"
+    | "var"
+    | "const"
+    | "enum"
+    | "const enum"
+    | "class"
+    | "function"
+    | "async function";
   code: string;
   start: number;
   end: number;
@@ -62,14 +70,6 @@ export interface NamedExport extends ESMExport {
 export interface DefaultExport extends ESMExport {
   type: "default";
 }
-
-export const DECLARATION_TYPES: ESMExport["declarationType"][] = [
-  "interface",
-  "type",
-  "enum",
-  "const",
-  "function",
-];
 
 export const ESM_STATIC_IMPORT_RE =
   /(?<=\s|^|;|\})import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu;
@@ -327,9 +327,10 @@ function normalizeExports(exports: (ESMExport & { declaration?: string })[]) {
       exp.names = [exp.name];
     }
     if (exp.type === "declaration") {
-      exp.declarationType = DECLARATION_TYPES.find((d) =>
-        exp.declaration.includes(d),
-      );
+      exp.declarationType = exp.declaration.replace(
+        /^declare\s*/,
+        "",
+      ) as ESMExport["declarationType"];
     }
   }
   return exports;

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -63,7 +63,13 @@ export interface DefaultExport extends ESMExport {
   type: "default";
 }
 
-export const DECLARATION_TYPES: ESMExport['declarationType'][] = ['interface', 'type', 'enum', 'const', 'function']
+export const DECLARATION_TYPES: ESMExport["declarationType"][] = [
+  "interface",
+  "type",
+  "enum",
+  "const",
+  "function",
+];
 
 export const ESM_STATIC_IMPORT_RE =
   /(?<=\s|^|;|\})import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu;
@@ -320,8 +326,10 @@ function normalizeExports(exports: (ESMExport & { declaration?: string })[]) {
     if (!exp.names && exp.name) {
       exp.names = [exp.name];
     }
-    if (exp.type === 'declaration') {
-      exp.declarationType = DECLARATION_TYPES.find(d => exp.declaration.includes(d))
+    if (exp.type === "declaration") {
+      exp.declarationType = DECLARATION_TYPES.find((d) =>
+        exp.declaration.includes(d),
+      );
     }
   }
   return exports;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -338,6 +338,7 @@ describe("findTypeExports", () => {
         {
           "code": "export type Bing",
           "declaration": "type",
+          "declarationType": "type",
           "end": 172,
           "name": "Bing",
           "names": [
@@ -349,6 +350,7 @@ describe("findTypeExports", () => {
         {
           "code": "export declare function getWidget",
           "declaration": "declare function",
+          "declarationType": "function",
           "end": 222,
           "name": "getWidget",
           "names": [

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -325,74 +325,167 @@ describe("findTypeExports", () => {
   it("finds type exports", () => {
     const matches = findTypeExports(
       `
-          export type { Foo } from "./foo";
-          export type { Bar } from "./bar";
-          interface Qux {}
+          export interface Qux {}
+
           export type { Qux }
           export type Bing = Qux
+          export type { Foo } from "./foo";
+          export type { Bar } from "./bar";
+
+          export declare let foo: string
+          export declare var bar: string
+          export declare const baz: string
+          export declare enum Qux { A, B, C }
+          export declare const enum Qux { A, B, C }
+          export declare class Foo {}
           export declare function getWidget(n: number): Widget
+          export declare async function loadWidget(n: number): Promise<Widget>
         `,
     );
     expect(matches).toMatchInlineSnapshot(`
       [
         {
+          "code": "export interface Qux",
+          "declaration": "interface",
+          "declarationType": "interface",
+          "end": 31,
+          "name": "Qux",
+          "names": [
+            "Qux",
+          ],
+          "start": 11,
+          "type": "declaration",
+        },
+        {
           "code": "export type Bing",
           "declaration": "type",
           "declarationType": "type",
-          "end": 172,
+          "end": 92,
           "name": "Bing",
           "names": [
             "Bing",
           ],
-          "start": 156,
+          "start": 76,
+          "type": "declaration",
+        },
+        {
+          "code": "export declare let foo",
+          "declaration": "declare let",
+          "declarationType": "let",
+          "end": 220,
+          "name": "foo",
+          "names": [
+            "foo",
+          ],
+          "start": 198,
+          "type": "declaration",
+        },
+        {
+          "code": "export declare var bar",
+          "declaration": "declare var",
+          "declarationType": "var",
+          "end": 261,
+          "name": "bar",
+          "names": [
+            "bar",
+          ],
+          "start": 239,
+          "type": "declaration",
+        },
+        {
+          "code": "export declare const baz",
+          "declaration": "declare const",
+          "declarationType": "const",
+          "end": 304,
+          "name": "baz",
+          "names": [
+            "baz",
+          ],
+          "start": 280,
+          "type": "declaration",
+        },
+        {
+          "code": "export declare const enum Qux",
+          "declaration": "declare const enum",
+          "declarationType": "const enum",
+          "end": 398,
+          "name": "Qux",
+          "names": [
+            "Qux",
+          ],
+          "start": 369,
+          "type": "declaration",
+        },
+        {
+          "code": "export declare class Foo",
+          "declaration": "declare class",
+          "declarationType": "class",
+          "end": 445,
+          "name": "Foo",
+          "names": [
+            "Foo",
+          ],
+          "start": 421,
           "type": "declaration",
         },
         {
           "code": "export declare function getWidget",
           "declaration": "declare function",
           "declarationType": "function",
-          "end": 222,
+          "end": 492,
           "name": "getWidget",
           "names": [
             "getWidget",
           ],
-          "start": 189,
+          "start": 459,
           "type": "declaration",
         },
         {
-          "code": "export type { Foo } from "./foo"",
-          "end": 43,
-          "exports": " Foo",
-          "name": "Foo",
+          "code": "export declare async function loadWidget",
+          "declaration": "declare async function",
+          "declarationType": "async function",
+          "end": 562,
+          "name": "loadWidget",
           "names": [
-            "Foo",
+            "loadWidget",
           ],
-          "specifier": "./foo",
-          "start": 11,
-          "type": "named",
-        },
-        {
-          "code": "export type { Bar } from "./bar"",
-          "end": 87,
-          "exports": " Bar",
-          "name": "Bar",
-          "names": [
-            "Bar",
-          ],
-          "specifier": "./bar",
-          "start": 55,
-          "type": "named",
+          "start": 522,
+          "type": "declaration",
         },
         {
           "code": "export type { Qux }",
-          "end": 145,
+          "end": 65,
           "exports": " Qux",
           "name": "Qux",
           "names": [
             "Qux",
           ],
           "specifier": undefined,
-          "start": 126,
+          "start": 46,
+          "type": "named",
+        },
+        {
+          "code": "export type { Foo } from "./foo"",
+          "end": 141,
+          "exports": " Foo",
+          "name": "Foo",
+          "names": [
+            "Foo",
+          ],
+          "specifier": "./foo",
+          "start": 109,
+          "type": "named",
+        },
+        {
+          "code": "export type { Bar } from "./bar"",
+          "end": 185,
+          "exports": " Bar",
+          "name": "Bar",
+          "names": [
+            "Bar",
+          ],
+          "specifier": "./bar",
+          "start": 153,
           "type": "named",
         },
       ]


### PR DESCRIPTION
### 🔗 Linked issue

Issue: #226

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [x] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

Add optional field *declarationType* in `ESMExport`. If export type is `declaration`, this field should be a string value like `interface` `type` `enum` `const` or `function`.
This approach can solve the issue of not being able to distinguish what specific type 'declaration' is.
Issue: #226 
Unimport issue: [#318](https://github.com/unjs/unimport/issues/318)
Unimport pull request: [fix re-export ts enum type](https://github.com/unjs/unimport/pull/325)

### 📝 Checklist

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
