### PR TITLE
fix(parseStaticImport): omit empty import names

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -128,7 +128,7 @@ export function parseStaticImport(
     const _match = namedImport.match(/^\s*(\S*) as (\S*)\s*$/);
     const source = _match?.[1] || namedImport.trim();
     const importName = _match?.[2] || source;
-    if (!TYPE_RE.test(source)) {
+    if (source && !TYPE_RE.test(source)) {
       namedImports[source] = importName;
     }
   }

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -49,6 +49,12 @@ const staticTests: Record<
         member3: "alias3",
       },
     },
+  'import { memberFormattedWithPrettier, } from "module-name";': {
+    specifier: "module-name",
+    namedImports: {
+      memberFormattedWithPrettier: "memberFormattedWithPrettier",
+    },
+  },
   'import { member1, /* member0point5, */ member2 as alias2, member3 as alias3 } from "module-name";':
     {
       specifier: "module-name",


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->
-

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

Hey @pi0,
the last release is causing problems for imports formatted by prettier, where the comma is added at the end, like
```ts
import {
  something,
  somethingElse,
} from "package"
```
that causes errors in unimport:
![image](https://github.com/unjs/mlly/assets/13100280/0c535f32-d926-4220-8fbb-bf28a1d6e4c0)

This PR fixes that and adds a test to make sure we're covering that case. Cheers!

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
