### PR TITLE
feat(isValidNodeImport): support `stripComments` option

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -68,7 +68,7 @@ export interface ValidNodeImportOptions extends ResolveOptions {
    *
    * Default: false
    */
-  stripCommentsFromCode?: boolean;
+  stripComments?: boolean;
 }
 
 const validNodeImportDefaults: ValidNodeImportOptions = {
@@ -121,5 +121,5 @@ export async function isValidNodeImport(
     (await fsp.readFile(resolvedPath, "utf8").catch(() => {})) ||
     "";
 
-  return !hasESMSyntax(code, { stripComments: options.stripCommentsFromCode });
+  return !hasESMSyntax(code, { stripComments: options.stripComments });
 }

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -63,6 +63,12 @@ export interface ValidNodeImportOptions extends ResolveOptions {
    * Default: ['node', 'file', 'data']
    */
   allowedProtocols?: Array<string>;
+  /**
+   * Whether to strip comments from the code before checking for ESM syntax.
+   *
+   * Default: false
+   */
+  stripCommentsFromCode?: boolean;
 }
 
 const validNodeImportDefaults: ValidNodeImportOptions = {
@@ -115,5 +121,5 @@ export async function isValidNodeImport(
     (await fsp.readFile(resolvedPath, "utf8").catch(() => {})) ||
     "";
 
-  return !hasESMSyntax(code);
+  return !hasESMSyntax(code, { stripComments: options.stripCommentsFromCode });
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue
https://github.com/huang-julien/nitro-applicationinsights/issues/58
https://github.com/unjs/nitro/issues/2308
<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description
hi :wave: this PR adds  a `stripCommentsFromCode` option for `isValidNodeImport`. 

I think the `stripComments` option from `detectSyntax` was made to avoid breaking anything in the ecosystem.

The issue lies in the non-legacy externals plugin in nitro which tries to inline `applicationinsights` import when it shouldn't due to applicationinsights having cjs syntax and esm syntax within its comments.

The goal of the PR is to open another PR in nitro to add a `stripCommentsFromCode` option for the `external` rollup plugin.

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
