### PR TITLE
docs: added jsdocs to exported functions and types

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -3,39 +3,133 @@ import { matchAll, clearImports, getImportNames } from "./_utils";
 import { resolvePath, ResolveOptions } from "./resolve";
 import { loadURL } from "./utils";
 
+/**
+ * Represents a general structure for ECMAScript module imports.
+ */
 export interface ESMImport {
+   /**
+   * Specifies the type of import: "static" for static imports and "dynamic" for dynamic imports.
+   */
   type: "static" | "dynamic";
+
+  /**
+   * The full import declaration code snippet as a string.
+   */
   code: string;
+
+  /**
+   * The starting position (index) of the import declaration in the source code.
+   */
   start: number;
+
+  /**
+   * The end position (index) of the import declaration in the source code.
+   */
   end: number;
 }
 
+/**
+ * Represents a static import declaration in an ECMAScript module.
+ * Extends {@link ESMImport}.
+ */
 export interface StaticImport extends ESMImport {
+  /**
+   * Indicates the type of import, specifically a static import.
+   */
   type: "static";
+
+  /**
+   * Contains the entire import statement as a string, excluding the module specifier.
+   */
   imports: string;
+
+  /**
+   * The module specifier from which imports are being brought in.
+   */
   specifier: string;
 }
 
+/**
+ * Represents a parsed static import declaration with detailed components of the import.
+ * Extends {@link StaticImport}.
+ */
 export interface ParsedStaticImport extends StaticImport {
+  /**
+   * The default import name, if any.
+   * @optional
+   */
   defaultImport?: string;
+
+  /**
+   * The namespace import name, if any, using the `* as` syntax.
+   * @optional
+   */
   namespacedImport?: string;
+
+  /**
+   * An object representing named imports, with their local aliases if specified.
+   * Each property key is the original name and its value is the alias.
+   * @optional
+   */
   namedImports?: { [name: string]: string };
 }
 
+/**
+ * Represents a dynamic import declaration that is loaded at runtime.
+ * Extends {@link ESMImport}.
+ */
 export interface DynamicImport extends ESMImport {
+  /**
+   * Indicates that this is a dynamic import.
+   */
   type: "dynamic";
+
+  /**
+   * The expression or path to be dynamically imported, typically a module path or URL.
+   */
   expression: string;
 }
 
+/**
+ * Represents a type-specific import, primarily used for importing types in TypeScript.
+ * Extends {@link ESMImport} but omits the 'type' to redefine it specifically for type imports.
+ */
 export interface TypeImport extends Omit<ESMImport, "type"> {
+  /**
+   * Specifies that this is a type import.
+   */
   type: "type";
+
+  /**
+   * Contains the entire type import statement as a string, excluding the module specifier.
+   */
   imports: string;
+
+  /**
+   * The module specifier from which to import types.
+   */
   specifier: string;
 }
 
+/**
+ * Represents a general structure for ECMAScript module exports.
+ */
 export interface ESMExport {
+  /**
+   * Optional explicit type for complex scenarios, often used internally.
+   * @optional
+   */
   _type?: "declaration" | "named" | "default" | "star";
+
+  /**
+   * The type of export (declaration, named, default or star).
+   */
   type: "declaration" | "named" | "default" | "star";
+
+  /**
+   * The specific type of declaration being exported, if applicable.
+   * @optional
+   */
   declarationType?:
     | "let"
     | "var"
@@ -45,41 +139,132 @@ export interface ESMExport {
     | "class"
     | "function"
     | "async function";
+
+  /**
+   * The full code snippet of the export statement.
+   */
   code: string;
+
+  /**
+   * The starting position (index) of the export declaration in the source code.
+   */
   start: number;
+ 
+  /**
+   * The end position (index) of the export declaration in the source code.
+   */
   end: number;
+
+  /**
+   * The name of the variable, function or class being exported, if given explicitly.
+   * @optional
+   */
   name?: string;
+
+  /**
+   * The name used for default exports when a specific identifier isn't given.
+   * @optional
+   */
   defaultName?: string;
+
+  /**
+   * An array of names to export, applicable to named and destructured exports.
+   */
   names: string[];
+
+  /**
+   * The module specifier, if any, from which exports are being re-exported.
+   * @optional
+   */
   specifier?: string;
 }
 
+/**
+ * Represents a declaration export within an ECMAScript module.
+ * Extends {@link ESMExport}.
+ */
 export interface DeclarationExport extends ESMExport {
+  /**
+   * Indicates that this export is a declaration export.
+   */
   type: "declaration";
+
+  /**
+   * The declaration string, such as 'let', 'const', 'class', etc., describing what is being exported.
+   */
   declaration: string;
+
+  /**
+   * The name of the declaration to be exported.
+   */
   name: string;
 }
 
+/**
+ * Represents a named export within an ECMAScript module.
+ * Extends {@link ESMExport}.
+ */
 export interface NamedExport extends ESMExport {
+  /**
+   * Specifies that this export is a named export.
+   */
   type: "named";
+
+  /**
+   * The export string, containing all exported identifiers.
+   */
   exports: string;
+
+  /**
+   * An array of names to export.
+   */
   names: string[];
+
+  /**
+   * The module specifier, if any, from which exports are being re-exported.
+   * @optional
+   */
   specifier?: string;
 }
 
+/**
+ * Represents a standard export within an ECMAScript module.
+ * Extends {@link ESMExport}.
+ */
 export interface DefaultExport extends ESMExport {
+  /**
+   * Specifies that this export is a standard export.
+   */
   type: "default";
 }
 
+/**
+ * Regular expression to match static import statements in JavaScript/TypeScript code.
+ * @example `import { foo, bar as baz } from 'module'`
+ */
 export const ESM_STATIC_IMPORT_RE =
   /(?<=\s|^|;|\})import\s*([\s"']*(?<imports>[\p{L}\p{M}\w\t\n\r $*,/{}@.]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gmu;
+
+/**
+ * Regular expression to match dynamic import statements in JavaScript/TypeScript code.
+ * @example `import('module')`
+ */
 export const DYNAMIC_IMPORT_RE =
   /import\s*\((?<expression>(?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)/gm;
 const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+([\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
 
+/**
+ * Regular expression to match various types of export declarations including variables, functions, and classes.
+ * @example `export const num = 1, str = 'hello'; export class Example {}`
+ */
 export const EXPORT_DECAL_RE =
   /\bexport\s+(?<declaration>(async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,\s*[\w$]+)*/g;
+
+/**
+ * Regular expression to match export declarations specifically for types, interfaces, and type aliases in TypeScript.
+ * @example `export type Result = { success: boolean; }; export interface User { name: string; age: number; };`
+ */
 export const EXPORT_DECAL_TYPE_RE =
   /\bexport\s+(?<declaration>(interface|type|declare (async function|function|let|const enum|const|enum|var|class)))\s+(?<name>[\w$]+)/g;
 const EXPORT_NAMED_RE =
@@ -94,6 +279,11 @@ const EXPORT_DEFAULT_RE =
   /\bexport\s+default\s+(async function|function|class|true|false|\W|\d)|\bexport\s+default\s+(?<defaultName>.*)/g;
 const TYPE_RE = /^\s*?type\s/;
 
+/**
+ * Finds all static import statements within the given code string.
+ * @param {string} code - The source code to search for static imports.
+ * @returns {StaticImport[]} An array of {@link StaticImport} objects representing each static import found.
+ */
 export function findStaticImports(code: string): StaticImport[] {
   return _filterStatement(
     _tryGetLocations(code, "import"),
@@ -101,6 +291,11 @@ export function findStaticImports(code: string): StaticImport[] {
   );
 }
 
+/**
+ * Searches for dynamic import statements in the given source code.
+ * @param {string} code - The source to search for dynamic imports in.
+ * @returns {DynamicImport[]} An array of {@link DynamicImport} objects representing each dynamic import found.
+ */
 export function findDynamicImports(code: string): DynamicImport[] {
   return _filterStatement(
     _tryGetLocations(code, "import"),
@@ -108,6 +303,12 @@ export function findDynamicImports(code: string): DynamicImport[] {
   );
 }
 
+/**
+ * Identifies and returns all type import statements in the given source code.
+ * This function is specifically targeted at type imports used in TypeScript.
+ * @param {string} code - The source code to search for type imports.
+ * @returns {TypeImport[]} An array of {@link TypeImport} objects representing each type import found.
+ */
 export function findTypeImports(code: string): TypeImport[] {
   return [
     ...matchAll(IMPORT_NAMED_TYPE_RE, code, { type: "type" }),
@@ -117,6 +318,11 @@ export function findTypeImports(code: string): TypeImport[] {
   ];
 }
 
+/**
+ * Parses a static import or type import to extract detailed import elements such as default, namespace and named imports.
+ * @param {StaticImport | TypeImport} matched - The matched import statement to parse. See {@link StaticImport} and {@link TypeImport}.
+ * @returns {ParsedStaticImport} A structured object representing the parsed static import. See {@link ParsedStaticImport}.
+ */
 export function parseStaticImport(
   matched: StaticImport | TypeImport,
 ): ParsedStaticImport {
@@ -142,6 +348,11 @@ export function parseStaticImport(
   } as ParsedStaticImport;
 }
 
+/**
+ * Parses a static import or type import to extract detailed import elements such as default, namespace and named imports.
+ * @param {StaticImport | TypeImport} matched - The matched import statement to parse. See {@link StaticImport} and {@link TypeImport}.
+ * @returns {ParsedStaticImport} A structured object representing the parsed static import. See {@link ParsedStaticImport}.
+ */
 export function parseTypeImport(
   matched: TypeImport | StaticImport,
 ): ParsedStaticImport {
@@ -174,6 +385,13 @@ export function parseTypeImport(
   } as ParsedStaticImport;
 }
 
+/**
+ * Identifies all export statements in the supplied source code and categorises them into different types such as declarations, named, default and star exports.
+ * This function processes the code to capture different forms of export statements and normalise their representation for further processing.
+ * 
+ * @param {string} code - The source code containing the export statements to be analysed.
+ * @returns {ESMExport[]} An array of {@link ESMExport} objects representing each export found, properly categorised and structured.
+ */
 export function findExports(code: string): ESMExport[] {
   // Find declarations like export const foo = 'bar'
   const declaredExports: DeclarationExport[] = matchAll(EXPORT_DECAL_RE, code, {
@@ -266,6 +484,13 @@ export function findExports(code: string): ESMExport[] {
   );
 }
 
+/**
+ * Searches specifically for type-related exports in TypeScript code, such as exported interfaces, types, and declarations prefixed with 'declare'.
+ * This function uses specialised regular expressions to identify type exports and normalises them for consistency.
+ * 
+ * @param {string} code - The TypeScript source code to search for type exports.
+ * @returns {ESMExport[]} An array of {@link ESMExport} objects representing each type export found.
+ */
 export function findTypeExports(code: string): ESMExport[] {
   // Find declarations like export const foo = 'bar'
   const declaredExports: DeclarationExport[] = matchAll(
@@ -345,12 +570,27 @@ function normalizeNamedExports(namedExports: NamedExport[]) {
   return namedExports;
 }
 
+/**
+ * Extracts and returns a list of all export names from the given source.
+ * This function uses {@link findExports} to retrieve all types of exports and consolidates their names into a single array.
+ *
+ * @param {string} code - The source code to search for export names.
+ * @returns {string[]} An array containing the names of all exports found in the code.
+ */
 export function findExportNames(code: string): string[] {
   return findExports(code)
     .flatMap((exp) => exp.names)
     .filter(Boolean);
 }
 
+/**
+ * Asynchronously resolves and returns all export names from a module specified by its module identifier.
+ * This function recursively resolves all explicitly named and asterisked (* as) exports to fully enumerate the exported identifiers.
+ *
+ * @param {string} id - The module identifier to resolve.
+ * @param {ResolveOptions} [options] - Optional settings for resolving the module path, such as the base URL.
+ * @returns {Promise<string[]>} A promise that resolves to an array of export names from the module.
+ */
 export async function resolveModuleExportNames(
   id: string,
   options?: ResolveOptions,

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -7,7 +7,7 @@ import { loadURL } from "./utils";
  * Represents a general structure for ECMAScript module imports.
  */
 export interface ESMImport {
-   /**
+  /**
    * Specifies the type of import: "static" for static imports and "dynamic" for dynamic imports.
    */
   type: "static" | "dynamic";
@@ -149,7 +149,7 @@ export interface ESMExport {
    * The starting position (index) of the export declaration in the source code.
    */
   start: number;
- 
+
   /**
    * The end position (index) of the export declaration in the source code.
    */
@@ -388,7 +388,7 @@ export function parseTypeImport(
 /**
  * Identifies all export statements in the supplied source code and categorises them into different types such as declarations, named, default and star exports.
  * This function processes the code to capture different forms of export statements and normalise their representation for further processing.
- * 
+ *
  * @param {string} code - The source code containing the export statements to be analysed.
  * @returns {ESMExport[]} An array of {@link ESMExport} objects representing each export found, properly categorised and structured.
  */
@@ -487,7 +487,7 @@ export function findExports(code: string): ESMExport[] {
 /**
  * Searches specifically for type-related exports in TypeScript code, such as exported interfaces, types, and declarations prefixed with 'declare'.
  * This function uses specialised regular expressions to identify type exports and normalises them for consistency.
- * 
+ *
  * @param {string} code - The TypeScript source code to search for type exports.
  * @returns {ESMExport[]} An array of {@link ESMExport} objects representing each type export found.
  */

--- a/src/cjs.ts
+++ b/src/cjs.ts
@@ -3,14 +3,34 @@ import { dirname } from "node:path";
 import { fileURLToPath } from "./utils";
 import { isObject } from "./_utils";
 
+/**
+ * Represents the context of a CommonJS environment, providing node-like module resolution capabilities within a module.
+ */
 export interface CommonjsContext {
+  /**
+   * The absolute path to the current module file.
+   */
   __filename: string;
+
+  /**
+   * The directory name of the current module.
+   */
   __dirname: string;
   // TODO!
   // eslint-disable-next-line no-undef
+  /**
+   * A function to require modules as in CommonJS.
+   */
   require: NodeRequire;
 }
 
+/**
+ * Creates a CommonJS context for a given module URL, enabling `require`, `__filename` and `__dirname` support similar to Node.js.
+ * This function dynamically generates a `require` function that is context-aware and bound to the location of the given module URL.
+ *
+ * @param {string} url - The URL of the module file to create a context for.
+ * @returns {CommonjsContext} A context object containing `__filename`, `__dirname` and a custom `require` function. See {@link CommonjsContext}.
+ */
 export function createCommonJS(url: string): CommonjsContext {
   const __filename = fileURLToPath(url);
   const __dirname = dirname(__filename);

--- a/src/eval.ts
+++ b/src/eval.ts
@@ -2,13 +2,28 @@ import { resolve } from "./resolve";
 import { loadURL, toDataURL } from "./utils";
 import type { ResolveOptions } from "./resolve";
 
+/**
+ * Options for evaluating or transforming modules, extending resolution options with optional URL specifications.
+ */
 export interface EvaluateOptions extends ResolveOptions {
+  /**
+   * The URL of the module, which can be specified to override the URL resolved from the module identifier.
+   * @optional
+   */
   url?: string;
 }
 
 const EVAL_ESM_IMPORT_RE =
   /(?<=import .* from ["'])([^"']+)(?=["'])|(?<=export .* from ["'])([^"']+)(?=["'])|(?<=import\s*["'])([^"']+)(?=["'])|(?<=import\s*\(["'])([^"']+)(?=["']\))/g;
 
+/**
+ * Loads a module by resolving its identifier to a URL, fetching the module's code and evaluating it.
+ *
+ * @param {string} id - The identifier of the module to load.
+ * @param {EvaluateOptions} options - Optional parameters to resolve and load the module. See {@link EvaluateOptions}.
+ * @returns {Promise<any>} A promise to resolve to the evaluated module.
+ * });
+ */
 export async function loadModule(
   id: string,
   options: EvaluateOptions = {},
@@ -18,6 +33,13 @@ export async function loadModule(
   return evalModule(code, { ...options, url });
 }
 
+/**
+ * Evaluates JavaScript code as a module using a dynamic import from a data URL.
+ *
+ * @param {string} code - The code of the module to evaluate.
+ * @param {EvaluateOptions} options - Includes the original URL of the module for better error mapping. See {@link EvaluateOptions}.
+ * @returns {Promise<any>} A promise that resolves to the evaluated module or throws an error if the evaluation fails.
+ */
 export async function evalModule(
   code: string,
   options: EvaluateOptions = {},
@@ -33,6 +55,13 @@ export async function evalModule(
   });
 }
 
+/**
+ * Transform module code to handle specific scenarios, such as converting JSON to a module or rewriting import.meta.url.
+ *
+ * @param {string} code - The code of the module to transform.
+ * @param {EvaluateOptions} options - Options to control how the code is transformed. See {@link EvaluateOptions}.
+ * @returns {Promise<string>} A promise that resolves to the transformed code.
+ */
 export function transformModule(
   code: string,
   options: EvaluateOptions = {},
@@ -50,6 +79,13 @@ export function transformModule(
   return Promise.resolve(code);
 }
 
+/**
+ * Resolves all import URLs found within the provided code to their absolute URLs, based on the given options.
+ *
+ * @param {string} code - The code containing the import directives to resolve.
+ * @param {EvaluateOptions} [options] - Options to use for resolving imports. See {@link EvaluateOptions}.
+ * @returns {Promise<string>} A promise that resolves to the code, replacing import URLs with resolved URLs.
+ */
 export async function resolveImports(
   code: string,
   options?: EvaluateOptions,

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -16,8 +16,19 @@ const NOT_FOUND_ERRORS = new Set([
 ]);
 
 export interface ResolveOptions {
+  /**
+   * A URL, path or array of URLs/paths to resolve against.
+   */
   url?: string | URL | (string | URL)[];
+
+  /**
+   * File extensions to consider when resolving modules.
+   */
   extensions?: string[];
+
+  /**
+   * Conditions to consider when resolving package exports.
+   */
   conditions?: string[];
 }
 
@@ -141,10 +152,24 @@ function _resolve(id: string | URL, options: ResolveOptions = {}): string {
   return pathToFileURL(resolved);
 }
 
+/**
+ * Synchronously resolves a module path based on the options provided.
+ *
+ * @param {string} id - The identifier or path of the module to resolve.
+ * @param {ResolveOptions} [options] - Options to resolve the module. See {@link ResolveOptions}.
+ * @returns {string} The resolved URL as a string.
+ */
 export function resolveSync(id: string, options?: ResolveOptions): string {
   return _resolve(id, options);
 }
 
+/**
+ * Asynchronously resolves a module path based on the given options.
+ *
+ * @param {string} id - The identifier or path of the module to resolve.
+ * @param {ResolveOptions} [options] - Options for resolving the module. See {@link ResolveOptions}.
+ * @returns {Promise<string>} A promise to resolve the URL as a string.
+ */
 export function resolve(id: string, options?: ResolveOptions): Promise<string> {
   try {
     return Promise.resolve(resolveSync(id, options));
@@ -153,10 +178,24 @@ export function resolve(id: string, options?: ResolveOptions): Promise<string> {
   }
 }
 
+/**
+ * Synchronously resolves a module path to a local file path based on the given options.
+ *
+ * @param {string} id - The identifier or path of the module to resolve.
+ * @param {ResolveOptions} [options] - Options to resolve the module. See {@link ResolveOptions}.
+ * @returns {string} The resolved file path.
+ */
 export function resolvePathSync(id: string, options?: ResolveOptions): string {
   return fileURLToPath(resolveSync(id, options));
 }
 
+/**
+ * Asynchronously resolves a module path to a local file path based on the options provided.
+ *
+ * @param {string} id - The identifier or path of the module to resolve.
+ * @param {ResolveOptions} [options] - Options for resolving the module. See {@link ResolveOptions}.
+ * @returns {Promise<string>} A promise to resolve to the file path.
+ */
 export function resolvePath(
   id: string,
   options?: ResolveOptions,
@@ -168,6 +207,12 @@ export function resolvePath(
   }
 }
 
+/**
+ * Creates a resolver function with default options that can be used to resolve module identifiers.
+ *
+ * @param {ResolveOptions} [defaults] - Default options to use for all resolutions. See {@link ResolveOptions}.
+ * @returns {Function} A resolver function that takes an identifier and an optional URL, and resolves the identifier using the default options and the given URL.
+ */
 export function createResolve(defaults?: ResolveOptions) {
   return (id: string, url?: ResolveOptions["url"]) => {
     return resolve(id, { url, ...defaults });
@@ -176,6 +221,12 @@ export function createResolve(defaults?: ResolveOptions) {
 
 const NODE_MODULES_RE = /^(.+\/node_modules\/)([^/@]+|@[^/]+\/[^/]+)(\/?.*?)?$/;
 
+/**
+ * Parses a node module path to extract the directory, name, and subpath.
+ *
+ * @param {string} path - The path to parse.
+ * @returns {Object} An object containing the directory, module name, and subpath of the node module.
+ */
 export function parseNodeModulePath(path: string) {
   if (!path) {
     return {};
@@ -193,7 +244,12 @@ export function parseNodeModulePath(path: string) {
   };
 }
 
-/** Reverse engineer a subpath export if possible */
+/**
+ * Attempts to reverse engineer a subpath export within a node module.
+ *
+ * @param {string} path - The path within the node module.
+ * @returns {Promise<string | undefined>} A promise that resolves to the detected subpath or undefined if not found.
+ */
 export async function lookupNodeModuleSubpath(
   path: string,
 ): Promise<string | undefined> {

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -22,7 +22,7 @@ export type DetectSyntaxOptions = {
    * Indicates whether comments should be stripped from the code before syntax checking.
    * @default false
    */
-  stripComments?: boolean
+  stripComments?: boolean;
 };
 
 /**

--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -14,8 +14,24 @@ const COMMENT_RE = /\/\*.+?\*\/|\/\/.*(?=[nr])/g;
 
 const BUILTIN_EXTENSIONS = new Set([".mjs", ".cjs", ".node", ".wasm"]);
 
-export type DetectSyntaxOptions = { stripComments?: boolean };
+/**
+ * Options for detecting syntax within a code string.
+ */
+export type DetectSyntaxOptions = {
+  /**
+   * Indicates whether comments should be stripped from the code before syntax checking.
+   * @default false
+   */
+  stripComments?: boolean
+};
 
+/**
+ * Determines if a given code string contains ECMAScript module syntax.
+ *
+ * @param {string} code - The source code to analyse.
+ * @param {DetectSyntaxOptions} opts - See {@link DetectSyntaxOptions}.
+ * @returns {boolean} `true` if the code contains ESM syntax, otherwise `false`.
+ */
 export function hasESMSyntax(
   code: string,
   opts: DetectSyntaxOptions = {},
@@ -26,6 +42,13 @@ export function hasESMSyntax(
   return ESM_RE.test(code);
 }
 
+/**
+ * Determines if a given string of code contains CommonJS syntax.
+ *
+ * @param {string} code - The source code to analyse.
+ * @param {DetectSyntaxOptions} opts - See {@link DetectSyntaxOptions}.
+ * @returns {boolean} `true` if the code contains CommonJS syntax, `false` otherwise.
+ */
 export function hasCJSSyntax(
   code: string,
   opts: DetectSyntaxOptions = {},
@@ -36,6 +59,13 @@ export function hasCJSSyntax(
   return CJS_RE.test(code);
 }
 
+/**
+ * Analyses the supplied code to determine if it contains ECMAScript module syntax, CommonJS syntax, or both.
+ *
+ * @param {string} code - The source code to analyse.
+ * @param {DetectSyntaxOptions} opts - See {@link DetectSyntaxOptions}.
+ * @returns {object} An object indicating the presence of ESM syntax (`hasESM`), CJS syntax (`hasCJS`) and whether both syntaxes are present (`isMixed`).
+ */
 export function detectSyntax(code: string, opts: DetectSyntaxOptions = {}) {
   if (opts.stripComments) {
     code = code.replace(COMMENT_RE, "");
@@ -60,13 +90,14 @@ export interface ValidNodeImportOptions extends ResolveOptions {
   /**
    * Protocols that are allowed as valid node imports.
    *
-   * Default: ['node', 'file', 'data']
+   * @default ['node', 'file', 'data']
+   *
    */
   allowedProtocols?: Array<string>;
   /**
    * Whether to strip comments from the code before checking for ESM syntax.
    *
-   * Default: false
+   * @default false
    */
   stripComments?: boolean;
 }
@@ -75,6 +106,13 @@ const validNodeImportDefaults: ValidNodeImportOptions = {
   allowedProtocols: ["node", "file", "data"],
 };
 
+/**
+ * Validates whether a given identifier represents a valid node import, based on its protocol, file extension, and optionally its contents.
+ *
+ * @param {string} id - The identifier or URL of the import to validate.
+ * @param {ValidNodeImportOptions} _options - Options for resolving and validating the import. See {@link ValidNodeImportOptions}.
+ * @returns {Promise<boolean>} A promise that resolves to `true` if the import is valid, otherwise `false`.
+ */
 export async function isValidNodeImport(
   id: string,
   _options: ValidNodeImportOptions = {},

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -5,6 +5,12 @@ import {
 import { promises as fsp } from "node:fs";
 import { normalizeSlash, BUILTIN_MODULES } from "./_utils";
 
+/**
+ * Converts a file URL to a local file system path with normalized slashes.
+ *
+ * @param {string | URL} id - The file URL or local path to convert.
+ * @returns {string} A normalized file system path.
+ */
 export function fileURLToPath(id: string | URL): string {
   if (typeof id === "string" && !id.startsWith("file://")) {
     return normalizeSlash(id);
@@ -12,6 +18,12 @@ export function fileURLToPath(id: string | URL): string {
   return normalizeSlash(_fileURLToPath(id));
 }
 
+/**
+ * Converts a local file system path to a file URL.
+ *
+ * @param {string | URL} id - The file system path to convert.
+ * @returns {string} The resulting file URL as a string.
+ */
 export function pathToFileURL(id: string | URL): string {
   return _pathToFileURL(fileURLToPath(id)).toString();
 }
@@ -20,12 +32,25 @@ export function pathToFileURL(id: string | URL): string {
 // eslint-disable-next-line no-control-regex
 const INVALID_CHAR_RE = /[\u0000-\u001F"#$&*+,/:;<=>?@[\]^`{|}\u007F]+/g;
 
+/**
+ * Sanitises a component of a URI by replacing invalid characters.
+ *
+ * @param {string} name - The URI component to sanitise.
+ * @param {string} [replacement="_"] - The string to replace invalid characters with.
+ * @returns {string} The sanitised URI component.
+ */
 export function sanitizeURIComponent(name = "", replacement = "_"): string {
   return name
     .replace(INVALID_CHAR_RE, replacement)
     .replace(/%../g, replacement);
 }
 
+/**
+ * Cleans a file path string by sanitising each component of the path.
+ *
+ * @param {string} filePath - The file path to sanitise.
+ * @returns {string} The sanitised file path.
+ */
 export function sanitizeFilePath(filePath = "") {
   return filePath
     .replace(/\?.*$/, "") // remove query string
@@ -35,6 +60,12 @@ export function sanitizeFilePath(filePath = "") {
     .replace(/^([A-Za-z])_\//, "$1:/");
 }
 
+/**
+ * Normalises a module identifier to ensure it has a protocol if missing, handling built-in modules and file paths.
+ *
+ * @param {string} id - The identifier to normalise.
+ * @returns {string} The normalised identifier with the appropriate protocol.
+ */
 export function normalizeid(id: string): string {
   if (typeof id !== "string") {
     // @ts-ignore
@@ -49,16 +80,34 @@ export function normalizeid(id: string): string {
   return "file://" + encodeURI(normalizeSlash(id));
 }
 
+/**
+ * Loads the contents of a file from a URL into a string.
+ *
+ * @param {string} url - The URL of the file to load.
+ * @returns {Promise<string>} A promise that resolves to the content of the file.
+ */
 export async function loadURL(url: string): Promise<string> {
   const code = await fsp.readFile(fileURLToPath(url), "utf8");
   return code;
 }
 
+/**
+ * Converts a string of code into a data URL that can be used for dynamic imports.
+ *
+ * @param {string} code - The string of code to convert.
+ * @returns {string} The data URL containing the encoded code.
+ */
 export function toDataURL(code: string): string {
   const base64 = Buffer.from(code).toString("base64");
   return `data:text/javascript;base64,${base64}`;
 }
 
+/**
+ * Checks if a module identifier matches a Node.js built-in module.
+ *
+ * @param {string} id - The identifier to check.
+ * @returns {boolean} `true` if the identifier is a built-in module, otherwise `false`.
+ */
 export function isNodeBuiltin(id = "") {
   // node:fs/promises => fs
   id = id.replace(/^node:/, "").split("/")[0];
@@ -69,6 +118,12 @@ export function isNodeBuiltin(id = "") {
 // "{2,}?" to make in ungreedy and dont take "file://C" as protocol
 const ProtocolRegex = /^(?<proto>.{2,}?):.+$/;
 
+/**
+ * Extracts the protocol portion of a given identifier string.
+ *
+ * @param {string} id - The identifier from which to extract the log.
+ * @returns {string | undefined} The protocol part of the identifier, or undefined if no protocol is present.
+ */
 export function getProtocol(id: string): string | undefined {
   const proto = id.match(ProtocolRegex);
   return proto ? proto.groups?.proto : undefined;


### PR DESCRIPTION
Added JSDocs to exported functions

### 🔗 Linked issue

<!-- Please ensure there is an open issue and mention its number as #123 -->

### ❓ Type of change

<!-- What types of changes does your code introduce? Put an `x` in all the boxes that apply. -->

- [X] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

<!-- Describe your changes in detail -->
<!-- Why is this change required? What problem does it solve? -->
<!-- If it resolves an open issue, please link to the issue here. For example "Resolves #1337" -->

### 📝 Checklist

<!-- Put an `x` in all the boxes that apply. -->
<!-- If your change requires a documentation PR, please link it appropriately -->
<!-- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [X] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.

> Any feedback is welcomed! 🙌

