### PR TITLE
refactor(interopDefault): simplify implementation

### DIFF
--- a/src/cjs.ts
+++ b/src/cjs.ts
@@ -51,31 +51,17 @@ export function interopDefault(
     return opts.preferNamespace ? sourceModule : defaultValue;
   }
   for (const key in sourceModule) {
-    if (key === "default") {
-      try {
-        if (!(key in defaultValue)) {
-          Object.defineProperty(defaultValue, key, {
-            enumerable: false,
-            configurable: false,
-            get() {
-              return defaultValue;
-            },
-          });
-        }
-      } catch {}
-    } else {
-      try {
-        if (!(key in defaultValue)) {
-          Object.defineProperty(defaultValue, key, {
-            enumerable: true,
-            configurable: true,
-            get() {
-              return sourceModule[key];
-            },
-          });
-        }
-      } catch {}
-    }
+    try {
+      if (!(key in defaultValue)) {
+        Object.defineProperty(defaultValue, key, {
+          enumerable: key !== "default",
+          configurable: key !== "default",
+          get() {
+            return sourceModule[key];
+          },
+        });
+      }
+    } catch {}
   }
   return defaultValue;
 }


### PR DESCRIPTION
<!---
☝️ PR title should follow conventional commits (https://conventionalcommits.org) 
-->

### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ ] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [x] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

While crafting https://github.com/antfu/unconfig/pull/27, I stumbled upon the implementation of `interopDefault`. Upon closer examination, I found out that the implementation could be simplified and redundant code could be merged.

All tests passed on my machine locally.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
