### PR TITLE
fix(findExports): find declaration export with inline object or array

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -79,7 +79,7 @@ const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+([\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
 
 export const EXPORT_DECAL_RE =
-  /\bexport\s+(?<declaration>(async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,\s*[\w$]+)*/g;
+  /\bexport\s+(?<declaration>(async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,\s*[\s\w:[\]{}]*[\w$\]}]+)*/g;
 export const EXPORT_DECAL_TYPE_RE =
   /\bexport\s+(?<declaration>(interface|type|declare (async function|function|let|const enum|const|enum|var|class)))\s+(?<name>[\w$]+)/g;
 const EXPORT_NAMED_RE =
@@ -185,9 +185,13 @@ export function findExports(code: string): ESMExport[] {
       | string
       | undefined;
     if (extraNamesStr) {
-      const extraNames = matchAll(/,\s*(?<name>\w+)/g, extraNamesStr, {}).map(
-        (m) => m.name,
-      );
+      const extraNames = matchAll(
+        /({.*?})|(\[.*?])|(,\s*(?<name>\w+))/g,
+        extraNamesStr,
+        {},
+      )
+        .map((m) => m.name)
+        .filter(Boolean);
       declaredExport.names = [declaredExport.name, ...extraNames];
     }
     delete (declaredExport as any).extraNames;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -86,6 +86,18 @@ describe("findExports", () => {
       type: "declaration",
       names: ["foo", "bar", "baz"],
     },
+    "export const foo = [ 1, bar, baz ];": {
+      type: "declaration",
+      names: ["foo"],
+    },
+    "export const foo = [ 1, bar ], baz = 2;": {
+      type: "declaration",
+      names: ["foo", "baz"],
+    },
+    "export const foo = { bar, bar1: [ qux , qux1 ] }, baz = 2;": {
+      type: "declaration",
+      names: ["foo", "baz"],
+    },
   };
 
   for (const [input, test] of Object.entries(tests)) {


### PR DESCRIPTION
### 🔗 Linked issue

N/A

### ❓ Type of change

- [ ] 📖 Documentation (updates to the documentation, readme, or JSdoc annotations)
- [ x] 🐞 Bug fix (a non-breaking change that fixes an issue)
- [ ] 👌 Enhancement (improving an existing functionality like performance)
- [ ] ✨ New feature (a non-breaking change that adds functionality)
- [ ] 🧹 Chore (updates to the build process or auxiliary tools and libraries)
- [ ] ⚠️ Breaking change (fix or feature that would cause existing functionality to change)

### 📚 Description

I find `findExports` got the wrong result from export inline object or array, such as: 
`export const foo = [ bar, baz, fgg ];`
or 
`export const foo = { bar, baz, fgg };`

It returns `[ "foo", "baz",  "fgg" ]`
but it should be only `[ "foo" ]`

I haven't checked other functions like `findTypeExports` `findTypeExports`

I have added some new tests and all tests passed on my machine locally.

### 📝 Checklist

- [ ] I have linked an issue or discussion.
- [ ] I have updated the documentation accordingly.
