### PR TITLE
fix(interopDefault): assign props to default function export

### DIFF
--- a/src/cjs.ts
+++ b/src/cjs.ts
@@ -67,7 +67,11 @@ export function interopDefault(
   if (defaultValue === undefined || defaultValue === null) {
     return sourceModule;
   }
-  if (typeof defaultValue !== "object") {
+  const _defaultType = typeof defaultValue;
+  if (
+    _defaultType !== "object" &&
+    !(_defaultType === "function" && !opts.preferNamespace)
+  ) {
     return opts.preferNamespace ? sourceModule : defaultValue;
   }
   for (const key in sourceModule) {

--- a/test/interop.test.ts
+++ b/test/interop.test.ts
@@ -50,4 +50,25 @@ describe("interopDefault", () => {
       }
     });
   }
+
+  it("function as default", () => {
+    const mod = {
+      default: () => {},
+      x: 123,
+    };
+
+    // Default behavior
+    const interop = interopDefault(mod);
+    expect(typeof interop).toBe("function");
+    expect(interop).toBe(mod.default);
+    expect(interop.x).toBe(123);
+    expect(interop.default).toBe(mod.default);
+
+    // With preferNamespace
+    const interopNS = interopDefault(mod, { preferNamespace: true });
+    expect(typeof interopNS).toBe("object");
+    expect(interopNS).toBe(mod);
+    expect(interopNS.x).toBe(123);
+    expect(interopNS.default).toBe(mod.default);
+  });
 });


### PR DESCRIPTION
Fixes regressions from https://github.com/unjs/jiti/issues/238

With https://github.com/unjs/mlly/commit/14eb72d0f571e06dcd127c0d5fec7b4fa49609f9, we no longer assign props to default export if it is a function that breaks many mixed cases.


**Note:** With new opt-in `preferNamespace` flag, we don't mix them anymore and return namespace as-is still.