### PR TITLE
fix: mark `names` field in `ESMExport` as possibly undefined

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -1,5 +1,9 @@
 import { builtinModules } from "node:module";
 
+// Regular expression with named groups
+export type RegExpWithGroups<T extends string> = RegExp & { __groups: T };
+type ExtractGroupNames<T> = T extends RegExpWithGroups<infer S> ? { [name in S]: string } : never;
+
 export const BUILTIN_MODULES = new Set(builtinModules);
 
 export function normalizeSlash(path: string): string {
@@ -10,12 +14,12 @@ export function isObject(value: unknown): boolean {
   return value !== null && typeof value === "object";
 }
 
-export function matchAll(regex: RegExp, string: string, addition: any) {
+export function matchAll<S extends string, T extends object>(regex: RegExpWithGroups<S>, string: string, addition: T) {
   const matches = [];
   for (const match of string.matchAll(regex)) {
     matches.push({
       ...addition,
-      ...match.groups,
+      ...match.groups as ExtractGroupNames<typeof regex>,
       code: match[0],
       start: match.index,
       end: (match.index || 0) + match[0].length,


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

The `names` field in `ESMExport` could be undefined as (indirectly) has been reported in https://github.com/nuxt/module-builder/issues/309.

This is now properly reflected in the types. Moreover, the regex group matches are now typed correctly.