### PR TITLE
fix(resolver): avoid double slashes when joining id with `/index`

### DIFF
--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -1278,12 +1278,10 @@ packages:
 
   glob@7.2.3:
     resolution: {integrity: sha512-nFR0zLpU2YCaRxwoCJvL6UvCH2JFyFVIvwTLsIf21AuHlMskA1hhTdk+LlYJtOlYt9v6dvszD2BGRqBL+iQK9Q==}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   glob@8.1.0:
     resolution: {integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==}
     engines: {node: '>=12'}
-    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution: {integrity: sha512-WOBp/EEGUiIsJSp7wcv/y6MO+lV9UoncWqxuFfm8eBwzWNgyfBd6Gz+IeKQ9jCmyhoH99g15M3T+QaVHFjizVA==}
@@ -1369,7 +1367,6 @@ packages:
 
   inflight@1.0.6:
     resolution: {integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==}
-    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution: {integrity: sha512-k/vGaX4/Yla3WzyMCvTQOXYeIHvqOKtnqBduzTHpzpQZzAskKMhZ2K+EnBiSM9zGSoIFeMpXKxa4dYeZIQqewQ==}

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -2312,6 +2312,7 @@ packages:
         integrity: sha512-r8hpEjiQEYlF2QU0df3dS+nxxSIreXQS1qRhMJM0Q5NDdR386C7jb7Hwwod8Fgiuex+k0GFjgft18yvxm5XoCQ==,
       }
     engines: { node: ">=12" }
+    deprecated: Glob versions prior to v9 are no longer supported
 
   globals@11.12.0:
     resolution:
@@ -2432,6 +2433,7 @@ packages:
       {
         integrity: sha512-k92I/b08q4wvFscXCLvqfsHCrjrF7yiXsQuIVvVE7N82W3+aqpzuUdBbfhWcy/FZR3/4IgflMgKLOsvPDrGCJA==,
       }
+    deprecated: This module is not supported, and leaks memory. Do not use it. Check out lru-cache if you want a good and tested way to coalesce async requests by a key value, which is much more comprehensive and powerful.
 
   inherits@2.0.4:
     resolution:

--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -122,7 +122,7 @@ function _resolve(id: string | URL, options: ResolveOptions = {}): string {
     for (const prefix of ["", "/index"]) {
       for (const extension of options.extensions || DEFAULT_EXTENSIONS) {
         resolved = _tryModuleResolve(
-          id + prefix + extension,
+          joinURL(id, prefix) + extension,
           url,
           conditionsSet,
         );

--- a/test/resolve.test.ts
+++ b/test/resolve.test.ts
@@ -15,44 +15,6 @@ const tests = [
   { input: "/non/existent", action: "throws" },
 ] as const;
 
-afterEach(() => {
-  vi.restoreAllMocks();
-});
-
-const { mockedResolve } = await vi.hoisted(async () => {
-  const importMetaResolve = await vi.importActual<
-    Record<string, (...args: unknown[]) => unknown>
-  >("import-meta-resolve");
-  return {
-    mockedResolve: vi.fn((id, url, conditions) => {
-      return importMetaResolve.moduleResolve(id, url, conditions);
-    }),
-  };
-});
-
-vi.mock("import-meta-resolve", () => {
-  return {
-    moduleResolve: mockedResolve,
-  };
-});
-
-describe("tryModuleResolve", () => {
-  it("should create correct url", () => {
-    expect(() =>
-      resolvePathSync("tslib/", {
-        url: import.meta.url.replace(
-          parseFilename(import.meta.url, { strict: false }) || "",
-          "",
-        ),
-      }),
-    ).toThrow();
-    expect(mockedResolve).toHaveBeenCalled();
-    expect(
-      mockedResolve.mock.calls.some((call) => call[0].includes("//")),
-    ).toBe(false);
-  });
-});
-
 describe("resolveSync", () => {
   for (const test of tests) {
     it(`${test.input} should ${test.action}`, () => {
@@ -119,4 +81,42 @@ describe("resolvePathSync", () => {
       }
     });
   }
+});
+
+// https://github.com/unjs/mlly/pull/278
+describe("tryModuleResolve", async () => {
+  const { mockedResolve } = await vi.hoisted(async () => {
+    const importMetaResolve = await vi.importActual<
+      Record<string, (...args: unknown[]) => unknown>
+    >("import-meta-resolve");
+    return {
+      mockedResolve: vi.fn((id, url, conditions) => {
+        return importMetaResolve.moduleResolve(id, url, conditions);
+      }),
+    };
+  });
+
+  afterEach(() => {
+    vi.restoreAllMocks();
+  });
+
+  it("should create correct url", () => {
+    vi.mock("import-meta-resolve", () => {
+      return {
+        moduleResolve: mockedResolve,
+      };
+    });
+    expect(() =>
+      resolvePathSync("tslib/", {
+        url: import.meta.url.replace(
+          parseFilename(import.meta.url, { strict: false }) || "",
+          "",
+        ),
+      }),
+    ).toThrow();
+    expect(mockedResolve).toHaveBeenCalled();
+    expect(
+      mockedResolve.mock.calls.some((call) => call[0].includes("//")),
+    ).toBe(false);
+  });
 });


### PR DESCRIPTION
Should fix DEP0166 (DeprecationWarning: Use of deprecated double slash resolving...) as mentioned in 

- nuxt/icon#140
- unjs/nitro#2523
- etc.

Will not fix DEP0155 (DeprecationWarning: Use of deprecated trailing slash pattern mapping "./" in the "exports" field...).