### PR TITLE
fix(findExportNames): do not require space before named exports

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -269,7 +269,7 @@ export const EXPORT_DECAL_TYPE_RE =
 const EXPORT_NAMED_RE =
   /\bexport\s*{(?<exports>[^}]+?)[\s,]*}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_NAMED_TYPE_RE =
-  /\bexport\s+type\s+{(?<exports>[^}]+?)[\s,]*}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
+  /\bexport\s+type\s*{(?<exports>[^}]+?)[\s,]*}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_NAMED_DESTRUCT =
   /\bexport\s+(let|var|const)\s+(?:{(?<exports1>[^}]+?)[\s,]*}|\[(?<exports2>[^\]]+?)[\s,]*])\s+=/gm;
 const EXPORT_STAR_RE =

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -267,7 +267,7 @@ export const EXPORT_DECAL_RE =
 export const EXPORT_DECAL_TYPE_RE =
   /\bexport\s+(?<declaration>(interface|type|declare (async function|function|let|const enum|const|enum|var|class)))\s+(?<name>[\w$]+)/g;
 const EXPORT_NAMED_RE =
-  /\bexport\s+{(?<exports>[^}]+?)[\s,]*}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
+  /\bexport\s*{(?<exports>[^}]+?)[\s,]*}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_NAMED_TYPE_RE =
   /\bexport\s+type\s+{(?<exports>[^}]+?)[\s,]*}(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_NAMED_DESTRUCT =

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -256,6 +256,14 @@ describe("findExportNames", () => {
         "default",
       ]
     `);
+    expect(
+      findExportNames(`export{a as globalMiddleware,d as namedMiddleware};`),
+    ).toMatchInlineSnapshot(`
+      [
+        "globalMiddleware",
+        "namedMiddleware",
+      ]
+    `);
   });
 });
 


### PR DESCRIPTION
previously we required a space `export {` but commonly minifiers omit it: `export{`