### PR TITLE
fix(findExports): exclude parameter names from function declaration export names

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -400,7 +400,7 @@ export function findExports(code: string): ESMExport[] {
   for (const declaredExport of declaredExports) {
     // function declarations don't have extra names
     if (/^export\s+(?:async\s+)?function/.test(declaredExport.code)) {
-      continue
+      continue;
     }
     const extraNamesStr = (declaredExport as any).extraNames as
       | string

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -398,6 +398,10 @@ export function findExports(code: string): ESMExport[] {
   });
   // Parse extra names (foo, bar)
   for (const declaredExport of declaredExports) {
+    // function declarations don't have extra names
+    if (/^export\s+(?:async\s+)?function/.test(declaredExport.code)) {
+      continue
+    }
     const extraNamesStr = (declaredExport as any).extraNames as
       | string
       | undefined;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -100,12 +100,12 @@ describe("findExports", () => {
     },
     "export function foo(a, b, c)": {
       type: "declaration",
-      names: ["foo"]
+      names: ["foo"],
     },
     "export async function foo(a, b, c)": {
       type: "declaration",
-      names: ["foo"]
-    }
+      names: ["foo"],
+    },
   };
 
   for (const [input, test] of Object.entries(tests)) {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -98,6 +98,14 @@ describe("findExports", () => {
       type: "declaration",
       names: ["foo", "baz"],
     },
+    "export function foo(a, b, c)": {
+      type: "declaration",
+      names: ["foo"]
+    },
+    "export async function foo(a, b, c)": {
+      type: "declaration",
+      names: ["foo"]
+    }
   };
 
   for (const [input, test] of Object.entries(tests)) {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

For exported function declarations (`export function(a, b, c)`), `findExports` includes the names of the function's parameter names as exported names.

The `EXPORT_DECAL_RE` regex that matches function declaration exports considers the parameters as 'extra names', but extra names only appear on variable declaration exports (const, let, var).

A simple check is added to prevent `findExports` to look for extra names matched by the regex on function declartion exports.