### PR TITLE
feat: support export default class in declaration exports

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -276,6 +276,8 @@ const EXPORT_STAR_RE =
   /\bexport\s*(\*)(\s*as\s+(?<name>[\w$]+)\s+)?\s*(\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_DEFAULT_RE =
   /\bexport\s+default\s+(async function|function|class|true|false|\W|\d)|\bexport\s+default\s+(?<defaultName>.*)/g;
+const EXPORT_DEFAULT_CLASS_RE =
+  /\bexport\s+default\s+(?<declaration>class)\s+(?<name>[\w$]+)/g;
 const TYPE_RE = /^\s*?type\s/;
 
 /**
@@ -447,6 +449,11 @@ export function findExports(code: string): ESMExport[] {
     name: "default",
   });
 
+  // Find export default class
+  const defaultClassExports = matchAll(EXPORT_DEFAULT_CLASS_RE, code, {
+    type: "declaration",
+  });
+
   // Find export star
   const starExports: ESMExport[] = matchAll(EXPORT_STAR_RE, code, {
     type: "star",
@@ -459,6 +466,7 @@ export function findExports(code: string): ESMExport[] {
     ...namedExports,
     ...destructuredExports,
     ...defaultExport,
+    ...defaultClassExports,
     ...starExports,
   ]);
 

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -238,6 +238,38 @@ export { type AType, type B as BType, foo } from 'foo'
     expect(matches[0].names[0]).toEqual("foo");
     expect(matches[0].name).toEqual("foo");
   });
+
+  it("export default class", () => {
+    const code = `export default class Foo`;
+    const matches = findExports(code);
+    expect(matches).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "export default class",
+          "defaultName": undefined,
+          "end": 20,
+          "name": "default",
+          "names": [
+            "default",
+          ],
+          "start": 0,
+          "type": "default",
+        },
+        {
+          "code": "export default class Foo",
+          "declaration": "class",
+          "declarationType": "class",
+          "end": 24,
+          "name": "Foo",
+          "names": [
+            "Foo",
+          ],
+          "start": 0,
+          "type": "declaration",
+        },
+      ]
+    `);
+  });
 });
 
 describe("findExportNames", () => {


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR introduces a new behavior that allows `export default class` statements to be recognized as both `declaration` and `default exports`.

### Why

Previously, `export default class Foo {}` was only treated as a `default export`. However, default-exported class should also be available as `type declarations` for use cases like:

```ts
export default class Foo {}

function bar(foo: Foo) {
  return 'bar'
}
```

This enables better auto-import support in tools like `unimport` and `unplugin-auto-import`.