### PR TITLE
fix: `EXPORT_DEFAULT_RE` to capture named exports

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -275,7 +275,7 @@ const EXPORT_NAMED_DESTRUCT =
 const EXPORT_STAR_RE =
   /\bexport\s*\*(?:\s*as\s+(?<name>[\w$]+)\s+)?\s*(?:\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_DEFAULT_RE =
-  /\bexport\s+default\s+(async function|function|class|true|false|\W|\d)|\bexport\s+default\s+(?<defaultName>.*)/g;
+  /\bexport\s+default\s+(?:(?:async function|function|class|true|false)\s+)?(?<defaultName>.*)/g;
 const EXPORT_DEFAULT_CLASS_RE =
   /\bexport\s+default\s+(?<declaration>class)\s+(?<name>[\w$]+)/g;
 const TYPE_RE = /^\s*?type\s/;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -333,9 +333,9 @@ export { type AType, type B as BType, foo } from 'foo'
     expect(matches).toMatchInlineSnapshot(`
       [
         {
-          "code": "export default class",
-          "defaultName": undefined,
-          "end": 20,
+          "code": "export default class Foo",
+          "defaultName": "Foo",
+          "end": 24,
           "name": "default",
           "names": [
             "default",


### PR DESCRIPTION
<!--
PLEASE DO THIS BEFORE SUBMITTING A PR

1) Make sure there is an issue covering the problem or idea first. If not, please create one. Reference it in the PR via "resolves #12312312" 
2) Please keep your changes minimal and split them if you need to.
3) Ensure there is a minimal reproduction attached for bug fixes.

This will greatly help speed up the review process.

Thanks for your contribution ❤️
-->

This PR fixes an issue I discovered in my previous PR where `export default class Foo` wasn't properly capturing the class name.

Please refer to:
https://github.com/unjs/mlly/blob/401d42983f6f3a9112658d67b0a92ba4fb1d7efa/test/exports.test.ts#L255-L265

The fix improves the regex pattern for better default export handling.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved default-export detection so exported names (e.g., classes, functions, values) are captured more reliably.

* **Tests**
  * Updated export-detection snapshot to reflect the corrected capture behavior.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/unjs/mlly/pull/322?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->
<!-- end of auto-generated comment: release notes by coderabbit.ai -->