### PR TITLE
refactor: use AST parsing for complex export name extraction

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -2,6 +2,7 @@ import { defineBuildConfig } from "unbuild";
 
 export default defineBuildConfig({
   declaration: true,
+  externals: ["oxc-parser"],
   rollup: {
     emitCJS: true,
     inlineDependencies: true,

--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
   },
   "dependencies": {
     "acorn": "^8.16.0",
+    "oxc-parser": "^0.116.0",
     "pathe": "^2.0.3",
     "pkg-types": "^1.3.1",
     "ufo": "^1.6.3"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -11,6 +11,9 @@ importers:
       acorn:
         specifier: ^8.16.0
         version: 8.16.0
+      oxc-parser:
+        specifier: ^0.116.0
+        version: 0.116.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3
@@ -84,6 +87,15 @@ packages:
   '@bcoe/v8-coverage@1.0.2':
     resolution: {integrity: sha512-6zABk/ECA/QYSCQ1NGiVwwbQerUCZ+TQbp64Q3AgmfNvurHH0j8TtXa1qbShXA6qqkpAj4V5W8pP6mLe1mcMqA==}
     engines: {node: '>=18'}
+
+  '@emnapi/core@1.8.1':
+    resolution: {integrity: sha512-AvT9QFpxK0Zd8J0jopedNm+w/2fIzvtPKPjqyw9jwvBaReTTqPBk9Hixaz7KbjimP+QNz605/XnjFcDAL2pqBg==}
+
+  '@emnapi/runtime@1.8.1':
+    resolution: {integrity: sha512-mehfKSMWjjNol8659Z8KxEMrdSJDDot5SXMq00dM8BN4o+CLNXQ0xH2V7EchNHV4RmbZLmmPdEaXZc5H2FXmDg==}
+
+  '@emnapi/wasi-threads@1.1.0':
+    resolution: {integrity: sha512-WI0DdZ8xFSbgMjR1sFsKABJ/C5OnRrjT06JXbZKexJGrDuPTzZdDYfFlsgcCXCyf+suG5QU2e/y1Wo2V/OapLQ==}
 
   '@esbuild/aix-ppc64@0.25.12':
     resolution: {integrity: sha512-Hhmwd6CInZ3dwpuGTF8fJG6yoWmsToE+vYgD4nytZVxcu1ulHpUQRAB1UJ8+N1Am3Mz4+xOByoQoSZf4D+CpkA==}
@@ -469,6 +481,131 @@ packages:
   '@jridgewell/trace-mapping@0.3.31':
     resolution: {integrity: sha512-zzNR+SdQSDJzc8joaeP8QQoCQr8NuYx2dIIytl1QeBEZHJ9uW6hebsrYgbz8hJwUQao3TWCMtmfV8Nu1twOLAw==}
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    resolution: {integrity: sha512-p64ah1M1ld8xjWv3qbvFwHiFVWrq1yFvV4f7w+mzaqiR4IlSgkqhcRdHwsGgomwzBH51sRY4NEowLxnaBjcW/A==}
+
+  '@oxc-parser/binding-android-arm-eabi@0.116.0':
+    resolution: {integrity: sha512-AOET7YIOU3+ANO/3xQeRVGN5Xx6+JGXaIwlqkcHSfxJ/zzw2B6jb0YaLhX45SeRluKVTU8rka4N/tHtNoJjoCg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [android]
+
+  '@oxc-parser/binding-android-arm64@0.116.0':
+    resolution: {integrity: sha512-yh0Zvth5cQ6XZkP3QF9MDrXf695zr5XxXq/wBQqpZb0uAgI9wpr98/Hx2RZITMfnNjkIq2VcyU44o3A0bdEmlQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [android]
+
+  '@oxc-parser/binding-darwin-arm64@0.116.0':
+    resolution: {integrity: sha512-plcTd/Jska55dToZz6XdRBPRVsj+asjD8QCpQFvt3Wj8pY+10D1pE53Mei3POAS/wSRSy7HiQ2twrm7H2A0CjA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [darwin]
+
+  '@oxc-parser/binding-darwin-x64@0.116.0':
+    resolution: {integrity: sha512-ahqcF3e3x5Z2ZepzXpZ8ugREdmxvBL+g1nQ0SxO11pIZfck6UtbOtwtdAAxnQXBHHtidu7lPcrBq1SEx26t1PQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [darwin]
+
+  '@oxc-parser/binding-freebsd-x64@0.116.0':
+    resolution: {integrity: sha512-yo2/LaSXtlzKBurvNbwun/sN/RJwW3XhbMr069FwNVtft7GBnaLLdPIz/sf47icxw/BPViEX6wFvzeD12mtrAg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [freebsd]
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.116.0':
+    resolution: {integrity: sha512-EiZeliIPPdFsuaPx8PzDMVijD/4YaUxO46/eYPk5raRocJqjjxOG6GAacQ8UrG3fbrgYjaEChfYL1e8DyE445A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.116.0':
+    resolution: {integrity: sha512-Nf7hnKRYRSIgglQcLAqE2St4b/Yr6dh+Z7in8mxol065Knevw71XZAiV1fmPSojq6uKPLV9eoH/wFrgr4TnZXw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.116.0':
+    resolution: {integrity: sha512-9SJI0S4Qggn3QHpT8Y1jtZceA0m4BlpvO3ne2Wxd33UdTHMmelAnrXryjWutHWQtjCzOwSnFBEoQAdNNyt1u3A==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-arm64-musl@0.116.0':
+    resolution: {integrity: sha512-wMZ6//GI+q1JwO7G2OR51+eA5P8Gr3BobU8RAzCGJptvyGMkWb7KQ1E8s8naVZRr6bSGWAL2p3mCzKOxmEPmrA==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.116.0':
+    resolution: {integrity: sha512-5BO0KCzTG2HZTnp3r6SCAOeCs/GwFBQJ1WAOG/ROfDf1fVVEy6hrtLKTLCuUMaamH38v+1+RVEmzRkzBj+rMDQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ppc64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.116.0':
+    resolution: {integrity: sha512-M24gYb/ocVMnLwnH2wY5sLt4sRBkAUHDmfiYtyUYdKTkfPOKtpopd5otsL/BPLnIhpMD8zby4uXVvw7BU0UIlw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.116.0':
+    resolution: {integrity: sha512-LHLXTHCH0bdvGjlitwr1ngeh32GAgq9HYzQ5VAgt0k0UT84AS8AkXj9Spoa9l20fXkVgSvAKcCEkydi4Ol23Dw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [riscv64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.116.0':
+    resolution: {integrity: sha512-VE+XsztuE5jdHvLIDIQMuyDpz5NJGq1Vx/8EXYF0sS/gehlv9GhDpGVWU0SCZ/LjzIy4io/Z0W84UudqufvP3g==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [s390x]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-gnu@0.116.0':
+    resolution: {integrity: sha512-rxUkauyjjCmgA7BoR63ogRGEtgubROnCm8AXE9ydg+p42jCGLLqG05mFcS2eC+FYyAU58ZFJNXXeqFW1iCyTGQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-linux-x64-musl@0.116.0':
+    resolution: {integrity: sha512-0zoZlk9MmXe6oTgSh5lT1D51SDC1bfwC96JmE1amMFAPdEbJk5MFRisfTN9TFBpBigQua65842tjaxqMiorAYw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [linux]
+
+  '@oxc-parser/binding-openharmony-arm64@0.116.0':
+    resolution: {integrity: sha512-PGS7Xqik77U9WMyW626gAD5A2rSN629UvyYJKAl/tgpT+KqZI4+56pJfExhv8IW/PpSHjYHwjmakwobLikz8ww==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [openharmony]
+
+  '@oxc-parser/binding-wasm32-wasi@0.116.0':
+    resolution: {integrity: sha512-lGNf/9PU8XxB4Gt1Gr1AKwSrjxGYa6os0PlrT4bpoQsfE3gaZonQTKwJyKhiQdgy7pBCI+ed1LB1NNib1FYULw==}
+    engines: {node: '>=14.0.0'}
+    cpu: [wasm32]
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.116.0':
+    resolution: {integrity: sha512-tcsOHE31duBSRQXZ7NfdtjmMKZwQYlS00PwAMJ4w5oXs3iPCvisUuIXP7Ko4FzeOBTRvkd64btxtQ6cRM0Kwlw==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [arm64]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.116.0':
+    resolution: {integrity: sha512-higCz/x+dOQ264YEk22hnu4RDqvjhfehjFORpxoh42QyUxsP6eIembYesBUu5ilALWo0HvRD+m89az2BSTwqpQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [ia32]
+    os: [win32]
+
+  '@oxc-parser/binding-win32-x64-msvc@0.116.0':
+    resolution: {integrity: sha512-Lg2SRmVHpGG85knDVLbv44r1bYn0OpIV0vg9jVmoEIpDj3Q4kwXuQ6MWVtuslwHR8o2CSiqdBeEn1n1URrs6Eg==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+    cpu: [x64]
+    os: [win32]
+
+  '@oxc-project/types@0.116.0':
+    resolution: {integrity: sha512-uOT8S1tlPmDckNxMNtIudN/yXpLdnhlJMX2oLS7cxCd7L0sUF09A/EbSVMWT3Y/iT44IwXCJSJfgfSxXAqWf9Q==}
+
   '@rollup/plugin-alias@5.1.1':
     resolution: {integrity: sha512-PR9zDb+rOzkRb2VD+EuKB7UC41vU5DIwZ5qqCpk0KJudcWAyi8rvYOhS7+L5aZCspw1stTViLgN5v6FF1p5cgQ==}
     engines: {node: '>=14.0.0'}
@@ -650,6 +787,9 @@ packages:
 
   '@standard-schema/spec@1.1.0':
     resolution: {integrity: sha512-l2aFy5jALhniG5HgqrD6jXLi/rUWrKvqN/qJx6yoJsgKhblVd+iqqU4RCXavm/jPityDo5TCvKMnpjKnOriy0w==}
+
+  '@tybys/wasm-util@0.10.1':
+    resolution: {integrity: sha512-9tTaPJLSiejZKx+Bmog4uSubteqTvFrVrURwkmHixBo0G4seD0zUxp98E1DzUBJxLQ3NPwXrGKDiVjwx/DpPsg==}
 
   '@types/chai@5.2.3':
     resolution: {integrity: sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==}
@@ -1560,6 +1700,10 @@ packages:
     resolution: {integrity: sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g==}
     engines: {node: '>= 0.8.0'}
 
+  oxc-parser@0.116.0:
+    resolution: {integrity: sha512-ugEo6wwqaqCGcpi7GsLCwSkoD7gIXzvtdaTxE+mbrXFYazU5Q9YdpZdAj9z2b79i/xlv+uW2aAvyzGAlpUzhKQ==}
+    engines: {node: ^20.19.0 || >=22.12.0}
+
   p-limit@3.1.0:
     resolution: {integrity: sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ==}
     engines: {node: '>=10'}
@@ -1911,6 +2055,9 @@ packages:
     peerDependencies:
       typescript: '>=4.8.4'
 
+  tslib@2.8.1:
+    resolution: {integrity: sha512-oJFu94HQb+KVduSUQL7wnpmqnfmLsOA/nAh6b6EH0wCEoK0/mPeXU6c3wKDV83MkOuHPRHtSXKKU99IBazS/2w==}
+
   type-check@0.4.0:
     resolution: {integrity: sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew==}
     engines: {node: '>= 0.8.0'}
@@ -2092,6 +2239,22 @@ snapshots:
       '@babel/helper-validator-identifier': 7.28.5
 
   '@bcoe/v8-coverage@1.0.2': {}
+
+  '@emnapi/core@1.8.1':
+    dependencies:
+      '@emnapi/wasi-threads': 1.1.0
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/runtime@1.8.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
+
+  '@emnapi/wasi-threads@1.1.0':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@esbuild/aix-ppc64@0.25.12':
     optional: true
@@ -2324,6 +2487,77 @@ snapshots:
       '@jridgewell/resolve-uri': 3.1.2
       '@jridgewell/sourcemap-codec': 1.5.5
 
+  '@napi-rs/wasm-runtime@1.1.1':
+    dependencies:
+      '@emnapi/core': 1.8.1
+      '@emnapi/runtime': 1.8.1
+      '@tybys/wasm-util': 0.10.1
+    optional: true
+
+  '@oxc-parser/binding-android-arm-eabi@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-android-arm64@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-arm64@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-darwin-x64@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-freebsd-x64@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-gnueabihf@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm-musleabihf@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-gnu@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-arm64-musl@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-ppc64-gnu@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-gnu@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-riscv64-musl@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-s390x-gnu@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-gnu@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-linux-x64-musl@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-openharmony-arm64@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-wasm32-wasi@0.116.0':
+    dependencies:
+      '@napi-rs/wasm-runtime': 1.1.1
+    optional: true
+
+  '@oxc-parser/binding-win32-arm64-msvc@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-ia32-msvc@0.116.0':
+    optional: true
+
+  '@oxc-parser/binding-win32-x64-msvc@0.116.0':
+    optional: true
+
+  '@oxc-project/types@0.116.0': {}
+
   '@rollup/plugin-alias@5.1.1(rollup@4.59.0)':
     optionalDependencies:
       rollup: 4.59.0
@@ -2447,6 +2681,11 @@ snapshots:
     optional: true
 
   '@standard-schema/spec@1.1.0': {}
+
+  '@tybys/wasm-util@0.10.1':
+    dependencies:
+      tslib: 2.8.1
+    optional: true
 
   '@types/chai@5.2.3':
     dependencies:
@@ -3655,6 +3894,31 @@ snapshots:
       type-check: 0.4.0
       word-wrap: 1.2.5
 
+  oxc-parser@0.116.0:
+    dependencies:
+      '@oxc-project/types': 0.116.0
+    optionalDependencies:
+      '@oxc-parser/binding-android-arm-eabi': 0.116.0
+      '@oxc-parser/binding-android-arm64': 0.116.0
+      '@oxc-parser/binding-darwin-arm64': 0.116.0
+      '@oxc-parser/binding-darwin-x64': 0.116.0
+      '@oxc-parser/binding-freebsd-x64': 0.116.0
+      '@oxc-parser/binding-linux-arm-gnueabihf': 0.116.0
+      '@oxc-parser/binding-linux-arm-musleabihf': 0.116.0
+      '@oxc-parser/binding-linux-arm64-gnu': 0.116.0
+      '@oxc-parser/binding-linux-arm64-musl': 0.116.0
+      '@oxc-parser/binding-linux-ppc64-gnu': 0.116.0
+      '@oxc-parser/binding-linux-riscv64-gnu': 0.116.0
+      '@oxc-parser/binding-linux-riscv64-musl': 0.116.0
+      '@oxc-parser/binding-linux-s390x-gnu': 0.116.0
+      '@oxc-parser/binding-linux-x64-gnu': 0.116.0
+      '@oxc-parser/binding-linux-x64-musl': 0.116.0
+      '@oxc-parser/binding-openharmony-arm64': 0.116.0
+      '@oxc-parser/binding-wasm32-wasi': 0.116.0
+      '@oxc-parser/binding-win32-arm64-msvc': 0.116.0
+      '@oxc-parser/binding-win32-ia32-msvc': 0.116.0
+      '@oxc-parser/binding-win32-x64-msvc': 0.116.0
+
   p-limit@3.1.0:
     dependencies:
       yocto-queue: 0.1.0
@@ -3984,6 +4248,9 @@ snapshots:
   ts-api-utils@2.4.0(typescript@5.9.3):
     dependencies:
       typescript: 5.9.3
+
+  tslib@2.8.1:
+    optional: true
 
   type-check@0.4.0:
     dependencies:

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -613,7 +613,10 @@ function _parseNamedExportsRe(exportsStr: string, keepTypes = false): string[] {
  * Batches multiple export code slices into a single parseSync call
  * and returns the parsed export names for each slice.
  */
-function _batchParseExportNames(codeSlices: string[], keepTypes = false): string[][] {
+function _batchParseExportNames(
+  codeSlices: string[],
+  keepTypes = false,
+): string[][] {
   const combined = codeSlices.join("\n");
   const { module } = parseSync("input.ts", combined, { sourceType: "module" });
   if (module.staticExports.length !== codeSlices.length) {

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,4 +1,5 @@
 import { tokenizer } from "acorn";
+import { parseSync } from "oxc-parser";
 import { matchAll, clearImports, getImportNames } from "./_utils";
 import { resolvePath, type ResolveOptions } from "./resolve";
 import { loadURL } from "./utils";
@@ -257,12 +258,14 @@ const IMPORT_NAMED_TYPE_RE =
 /**
  * Regular expression to match various types of export declarations including variables, functions, and classes.
  * @example `export const num = 1, str = 'hello'; export class Example {}`
+ * @deprecated Use `findExports()` instead, which now uses AST-based parsing.
  */
 export const EXPORT_DECAL_RE =
   /\bexport\s+(?<declaration>(?:async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,\s*[\s\w:[\]{}]*[\w$\]}]+)*/g;
 /**
  * Regular expression to match export declarations specifically for types, interfaces, and type aliases in TypeScript.
  * @example `export type Result = { success: boolean; }; export interface User { name: string; age: number; };`
+ * @deprecated Use `findTypeExports()` instead, which now uses AST-based parsing.
  */
 export const EXPORT_DECAL_TYPE_RE =
   /\bexport\s+(?<declaration>(?:interface|type|declare (?:async function|function|let|const enum|const|enum|var|class)))\s+(?<name>[\w$]+)/g;
@@ -279,6 +282,8 @@ const EXPORT_DEFAULT_RE =
 const EXPORT_DEFAULT_CLASS_RE =
   /\bexport\s+default\s+(?<declaration>class)\s+(?<name>[\w$]+)/g;
 const TYPE_RE = /^\s*?type\s/;
+const EXPORT_FUNCTION_RE = /^export\s+(?:async\s+)?function/;
+const EXPORT_STRING_LITERAL_RE = /['"]/;
 
 /**
  * Finds all static import statements within the given code string.
@@ -387,86 +392,6 @@ export function parseTypeImport(
 }
 
 /**
- * Extracts extra variable names from a comma-separated declaration list,
- * ignoring commas nested inside parentheses, brackets, braces, generics, or strings.
- *
- * For `export const foo = fn('a', bar), baz = 2`, only `baz` should be
- * extracted — commas inside `fn(...)` or `Handler<A, B>` are not declaration separators.
- * @param {string} extraNamesStr - The string containing the extra variable declarations to parse.
- * @returns {string[]} An array of variable names extracted from the declaration list.
- */
-function _extractExtraNames(extraNamesStr: string): string[] {
-  const names: string[] = [];
-  let depth = 0;
-  let angleDepth = 0;
-  let inString: string | false = false;
-  let inTypeAnnotation = false;
-
-  for (let i = 0; i < extraNamesStr.length; i++) {
-    const char = extraNamesStr[i];
-
-    // Handle string literals — skip their contents entirely
-    if (inString) {
-      if (char === inString) {
-        let backslashCount = 0;
-        for (let j = i - 1; j >= 0 && extraNamesStr[j] === "\\"; j--) {
-          backslashCount++;
-        }
-        if (backslashCount % 2 === 0) {
-          inString = false;
-        }
-      }
-      continue;
-    }
-    if (char === '"' || char === "'" || char === "`") {
-      inString = char;
-      continue;
-    }
-
-    // Track type annotations (between `:` and `=` at depth 0) for generic angle brackets
-    if (char === ":" && depth === 0 && angleDepth === 0) {
-      inTypeAnnotation = true;
-      continue;
-    }
-    if (
-      char === "=" &&
-      extraNamesStr[i + 1] !== ">" &&
-      depth === 0 &&
-      angleDepth === 0
-    ) {
-      inTypeAnnotation = false;
-    }
-    if (inTypeAnnotation && char === "<") {
-      angleDepth++;
-      continue;
-    }
-    if (inTypeAnnotation && char === ">" && angleDepth > 0) {
-      angleDepth--;
-      continue;
-    }
-
-    // Track bracket nesting
-    if (char === "(" || char === "[" || char === "{") {
-      depth++;
-    } else if (char === ")" || char === "]" || char === "}") {
-      depth--;
-    }
-
-    // A comma at depth 0 (outside generics) is a real declaration separator
-    if (char === "," && depth === 0 && angleDepth === 0) {
-      // Extract the identifier that follows this comma
-      const rest = extraNamesStr.slice(i + 1);
-      const match = rest.match(/^\s*([\w$]+)/);
-      if (match) {
-        names.push(match[1]);
-      }
-    }
-  }
-
-  return names;
-}
-
-/**
  * Identifies all export statements in the supplied source code and categorises them into different types such as declarations, named, default and star exports.
  * This function processes the code to capture different forms of export statements and normalise their representation for further processing.
  *
@@ -478,30 +403,11 @@ export function findExports(code: string): ESMExport[] {
   const declaredExports: DeclarationExport[] = matchAll(EXPORT_DECAL_RE, code, {
     type: "declaration",
   });
-  // Parse extra names (foo, bar)
-  for (const declaredExport of declaredExports) {
-    // function declarations don't have extra names
-    if (/^export\s+(?:async\s+)?function/.test(declaredExport.code)) {
-      continue;
-    }
-    const extraNamesStr = (declaredExport as any).extraNames as
-      | string
-      | undefined;
-    if (extraNamesStr) {
-      const extraNames = _extractExtraNames(extraNamesStr);
-      if (extraNames.length > 0) {
-        declaredExport.names = [declaredExport.name, ...extraNames];
-      }
-    }
-    delete (declaredExport as any).extraNames;
-  }
 
   // Find named exports
-  const namedExports: NamedExport[] = normalizeNamedExports(
-    matchAll(EXPORT_NAMED_RE, code, {
-      type: "named",
-    }),
-  );
+  const namedExports: NamedExport[] = matchAll(EXPORT_NAMED_RE, code, {
+    type: "named",
+  });
 
   const destructuredExports: NamedExport[] = matchAll(
     EXPORT_NAMED_DESTRUCT,
@@ -511,16 +417,43 @@ export function findExports(code: string): ESMExport[] {
   for (const namedExport of destructuredExports) {
     // @ts-expect-error groups
     namedExport.exports = namedExport.exports1 || namedExport.exports2;
-    namedExport.names = namedExport.exports
-      .replace(/^\r?\n?/, "")
-      .split(/\s*,\s*/g)
-      .filter((name) => !TYPE_RE.test(name))
-      .map((name) =>
-        name
-          .replace(/^.*?\s*:\s*/, "")
-          .replace(/\s*=\s*.*$/, "")
-          .trim(),
-      );
+  }
+
+  // Collect all code slices that need AST parsing and batch them into a single parseSync call
+  const needsParse: ESMExport[] = [];
+
+  for (const declaredExport of declaredExports) {
+    const extraNamesStr = (declaredExport as any).extraNames as
+      | string
+      | undefined;
+    delete (declaredExport as any).extraNames;
+    if (!EXPORT_FUNCTION_RE.test(declaredExport.code) && extraNamesStr) {
+      // Extra names can contain commas inside values: `export const foo = [1, 2], bar = 3`,
+      // `export const foo = fn(a, b), bar = 3`, generics in type annotations, etc.
+      needsParse.push(declaredExport);
+    }
+  }
+
+  for (const namedExport of namedExports) {
+    // String literals in export names can contain commas: `export { foo as "bar, baz" }` (ES2022)
+    if (EXPORT_STRING_LITERAL_RE.test(namedExport.exports)) {
+      needsParse.push(namedExport);
+    } else {
+      namedExport.names = _parseNamedExportsRe(namedExport.exports);
+    }
+  }
+
+  // Default values in destructuring can contain commas: `export const { foo = fn(a, b) } = obj`
+  for (const destructuredExport of destructuredExports) {
+    needsParse.push(destructuredExport);
+  }
+
+  if (needsParse.length > 0) {
+    // Get the export names for each export
+    const parsedExports = _batchParseExportNames(needsParse.map((e) => e.code));
+    for (const [i, target] of needsParse.entries()) {
+      target.names = parsedExports[i];
+    }
   }
 
   // Find export default
@@ -591,11 +524,29 @@ export function findTypeExports(code: string): ESMExport[] {
   );
 
   // Find named exports
-  const namedExports: NamedExport[] = normalizeNamedExports(
-    matchAll(EXPORT_NAMED_TYPE_RE, code, {
-      type: "named",
-    }),
-  );
+  const namedExports: NamedExport[] = matchAll(EXPORT_NAMED_TYPE_RE, code, {
+    type: "named",
+  });
+
+  const needsParse: NamedExport[] = [];
+  for (const namedExport of namedExports) {
+    // String literals in export names can contain commas: `export { foo as "bar, baz" }` (ES2022)
+    if (EXPORT_STRING_LITERAL_RE.test(namedExport.exports)) {
+      needsParse.push(namedExport);
+    } else {
+      namedExport.names = _parseNamedExportsRe(namedExport.exports, true);
+    }
+  }
+
+  if (needsParse.length > 0) {
+    const names = _batchParseExportNames(
+      needsParse.map((e) => e.code),
+      true,
+    );
+    for (const [i, target] of needsParse.entries()) {
+      target.names = names[i];
+    }
+  }
 
   // Merge and normalize exports
   const exports: ESMExport[] = normalizeExports([
@@ -650,15 +601,32 @@ function normalizeExports(exports: (ESMExport & { declaration?: string })[]) {
   return exports;
 }
 
-function normalizeNamedExports(namedExports: NamedExport[]) {
-  for (const namedExport of namedExports) {
-    namedExport.names = namedExport.exports
-      .replace(/^\r?\n?/, "")
-      .split(/\s*,\s*/g)
-      .filter((name) => !TYPE_RE.test(name))
-      .map((name) => name.replace(/^.*?\sas\s/, "").trim());
+function _parseNamedExportsRe(exportsStr: string, keepTypes = false): string[] {
+  return exportsStr
+    .replace(/^\r?\n?/, "")
+    .split(/\s*,\s*/g)
+    .filter((name) => name && (keepTypes || !TYPE_RE.test(name)))
+    .map((name) => name.replace(/^.*?\sas\s/, "").trim());
+}
+
+/**
+ * Batches multiple export code slices into a single parseSync call
+ * and returns the parsed export names for each slice.
+ */
+function _batchParseExportNames(codeSlices: string[], keepTypes = false): string[][] {
+  const combined = codeSlices.join("\n");
+  const { module } = parseSync("input.ts", combined, { sourceType: "module" });
+  if (module.staticExports.length !== codeSlices.length) {
+    throw new Error(
+      `Expected ${codeSlices.length} exports but parsed ${module.staticExports.length}`,
+    );
   }
-  return namedExports;
+  return module.staticExports.map((e) =>
+    e.entries
+      .filter((e) => keepTypes || !e.isType)
+      // safe to non-null assert because we don't parse bare star exports without specifiers `export * from 'module'`
+      .map((e) => e.exportName.name!),
+  );
 }
 
 /**

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -79,9 +79,18 @@ describe("findExports", () => {
     },
     "export enum bar { a = 'xx' }": { type: "declaration", names: ["bar"] },
     "export const { a, b } = foo": { type: "named", names: ["a", "b"] },
+    "export const { a: b, c } = foo": { type: "named", names: ["b", "c"] },
     "export const [ a, b ] = foo": { type: "named", names: ["a", "b"] },
     "export const [\na\n, b ] = foo": { type: "named", names: ["a", "b"] },
-    "export const [ a:b,\nc = 1] = foo": { type: "named", names: ["b", "c"] },
+    "export const [ a,\nb = 1 ] = foo": { type: "named", names: ["a", "b"] },
+    "export const { foo = fn(a, b), bar } = obj": {
+      type: "named",
+      names: ["foo", "bar"],
+    },
+    "export const [a = fn(1, 2), b] = arr": {
+      type: "named",
+      names: ["a", "b"],
+    },
     "export const foo = 1, bar,baz=3;": {
       type: "declaration",
       names: ["foo", "bar", "baz"],
@@ -145,6 +154,15 @@ describe("findExports", () => {
       name: "foo",
       names: ["foo"],
     },
+    "export function* generatorFn() {}": {
+      type: "declaration",
+      names: ["generatorFn"],
+    },
+    "export const a: Record<string, string> = {}, b: Map<number, Set<string>> = new Map()":
+      {
+        type: "declaration",
+        names: ["a", "b"],
+      },
   };
 
   for (const [input, test] of Object.entries(tests)) {
@@ -169,6 +187,30 @@ describe("findExports", () => {
       }
     });
   }
+
+  it("doesn't treat generic arrow function params as extra exports", () => {
+    const code = `export const foo = <T extends Record<string, Ref>>(a: string, b?: Record<string, unknown>): (c?: string) => T => { return () => ({} as T) }, bar = false, baz = (x: string, y: string) => { return x };`;
+    const matches = findExports(code);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toEqual(["foo", "bar", "baz"]);
+  });
+
+  // TODO: support nested destructuring
+  it.fails("export const { foo = { a: 1, b: 2 }, bar } = obj", () => {
+    const matches = findExports(
+      "export const { foo = { a: 1, b: 2 }, bar } = obj",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toEqual(["foo", "bar"]);
+  });
+  it.fails("export const { foo, bar: { baz, qux } } = obj", () => {
+    const matches = findExports(
+      "export const { foo, bar: { baz, qux } } = obj",
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toEqual(["foo", "baz", "qux"]);
+  });
+
   it("handles multiple exports", () => {
     const matches = findExports(`
           export { useTestMe1 } from "@/test/foo1";
@@ -287,7 +329,7 @@ export { type AType, type B as BType, foo } from 'foo'
   });
 
   it("export default class", () => {
-    const code = `export default class Foo`;
+    const code = `export default class Foo {}`;
     const matches = findExports(code);
     expect(matches).toMatchInlineSnapshot(`
       [
@@ -423,6 +465,19 @@ export { foo } from 'foo1';export { bar } from 'foo2';export * as foobar from 'f
 `;
     const matches = findExports(code);
     expect(matches).to.have.lengthOf(3);
+  });
+
+  it("handles TSX code", () => {
+    const code = `
+export const App = () => <div>hello</div>;
+export function Wrapper() { return <span />; }
+export default function Main() { return <p />; }
+`;
+    const matches = findExports(code);
+    expect(matches).to.have.lengthOf(3);
+    expect(matches[0]).toMatchObject({ name: "App", type: "declaration" });
+    expect(matches[1]).toMatchObject({ name: "Wrapper", type: "declaration" });
+    expect(matches[2]).toMatchObject({ name: "default", type: "default" });
   });
 });
 

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -328,6 +328,22 @@ export { type AType, type B as BType, foo } from 'foo'
     expect(matches[0].name).toEqual("foo");
   });
 
+  it("handles string literal export names (ES2022)", () => {
+    const matches = findExports('export { foo as "bar, baz" }');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toEqual("named");
+    expect(matches[0].names).toEqual(["bar, baz"]);
+  });
+
+  it("handles string literal export names with specifier", () => {
+    const matches = findExports(
+      'export { foo as "bar, baz" } from "./mod"',
+    );
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toEqual(["bar, baz"]);
+    expect(matches[0].specifier).toEqual("./mod");
+  });
+
   it("export default class", () => {
     const code = `export default class Foo {}`;
     const matches = findExports(code);
@@ -482,6 +498,18 @@ export default function Main() { return <p />; }
 });
 
 describe("findTypeExports", () => {
+  it("returns empty array when no type exports exist", () => {
+    const matches = findTypeExports("export const x = 1");
+    expect(matches).toEqual([]);
+  });
+
+  it("handles string literal type export names (ES2022)", () => {
+    const matches = findTypeExports('export type { Foo as "bar, baz" }');
+    expect(matches).toHaveLength(1);
+    expect(matches[0].type).toEqual("named");
+    expect(matches[0].names).toEqual(["bar, baz"]);
+  });
+
   it("finds type exports", () => {
     const matches = findTypeExports(
       `

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -336,9 +336,7 @@ export { type AType, type B as BType, foo } from 'foo'
   });
 
   it("handles string literal export names with specifier", () => {
-    const matches = findExports(
-      'export { foo as "bar, baz" } from "./mod"',
-    );
+    const matches = findExports('export { foo as "bar, baz" } from "./mod"');
     expect(matches).toHaveLength(1);
     expect(matches[0].names).toEqual(["bar, baz"]);
     expect(matches[0].specifier).toEqual("./mod");


### PR DESCRIPTION
fix https://github.com/unjs/unimport/issues/502
fix https://github.com/unjs/unimport/issues/500
fix https://github.com/nuxt/nuxt/issues/34432
fix https://github.com/nuxt/nuxt/issues/34407
fix https://github.com/unjs/unimport/issues/273 (possibly?)

This replaces @danielroe's solution for handling commas in export statemens from https://github.com/unjs/mlly/pull/336 with a proper AST-based parser, which should handle the remaining edge cases.

Probably the main difference compared the current implementation in `main` is that the function can now fail if we try to parse non-valid JavaScript syntax.

Other than that, it is _mostly_ identical in terms of performance in the majority of cases. We still use a regex to find the exports and only parse the ones that actually need it, reducing the performance impact significantly.

In the more complex cases where parsing does need to happen, all code slices are batched into a single `parseSync` call, which has also proven to speed things up a lot. The calls where we parse the code are ~1.5x slower than the old regex-only approach, but it no longer produces incorrect results.


----
For now, I haven't touched the part of the code that uses `acorn` for getting token locations. I haven't measured the performance of `acorn`, but I feel like tokenizing is much lighter than parsing the entire source file via `oxc-parser`... Maybe we can revisit this in the future?

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **New Features**
  * More robust export name detection using AST-based batching for complex patterns (destructuring with renames/defaults, generators, multi-typed declarations, ES2022 string-literal names) and improved TypeScript/TSX handling.

* **Tests**
  * Expanded coverage for TSX/JSX, advanced destructuring, string-literal exports/types, generators, nested edge cases, and other export parsing scenarios.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->