### PR TITLE
fix: generic angle bracket parsing

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -441,7 +441,13 @@ function _extractExtraNames(extraNamesStr: string): string[] {
       angleDepth++;
       continue;
     }
-    if (!inTypeAnnotation && char === "<" && depth === 0 && i > 0 && /[A-Za-z_$]/.test(extraNamesStr[i - 1])) {
+    if (
+      !inTypeAnnotation &&
+      char === "<" &&
+      depth === 0 &&
+      i > 0 &&
+      /[A-Za-z_$]/.test(extraNamesStr[i - 1])
+    ) {
       angleDepth++;
       continue;
     }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -451,7 +451,7 @@ function _extractExtraNames(extraNamesStr: string): string[] {
       angleDepth++;
       continue;
     }
-    if (char === ">" && angleDepth > 0) {
+    if (char === ">" && angleDepth > 0 && extraNamesStr[i - 1] !== "=") {
       angleDepth--;
       continue;
     }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -446,7 +446,7 @@ function _extractExtraNames(extraNamesStr: string): string[] {
       char === "<" &&
       depth === 0 &&
       i > 0 &&
-      /[A-Za-z_$]/.test(extraNamesStr[i - 1])
+      /[\w$]/.test(extraNamesStr[i - 1])
     ) {
       angleDepth++;
       continue;

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -436,11 +436,16 @@ function _extractExtraNames(extraNamesStr: string): string[] {
     ) {
       inTypeAnnotation = false;
     }
+    // Track angle brackets for generics (`Map<T>` vs comparison `x < y`)
     if (inTypeAnnotation && char === "<") {
       angleDepth++;
       continue;
     }
-    if (inTypeAnnotation && char === ">" && angleDepth > 0) {
+    if (!inTypeAnnotation && char === "<" && depth === 0 && i > 0 && /[A-Za-z_$]/.test(extraNamesStr[i - 1])) {
+      angleDepth++;
+      continue;
+    }
+    if (char === ">" && angleDepth > 0) {
       angleDepth--;
       continue;
     }

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -446,7 +446,7 @@ function _extractExtraNames(extraNamesStr: string): string[] {
       char === "<" &&
       depth === 0 &&
       i > 0 &&
-      /[\w$]/.test(extraNamesStr[i - 1])
+      _isIdentifierBeforeAngleBracket(extraNamesStr, i)
     ) {
       angleDepth++;
       continue;
@@ -774,4 +774,19 @@ function _getLocations(code: string, label: string) {
     }
   }
   return locations;
+}
+
+/**
+ * Check if `<` at position `i` is preceded by an identifier (not a bare number).
+ * `Map2<T>` → true (identifier ends with digit), `1<2` → false (bare number).
+ */
+function _isIdentifierBeforeAngleBracket(str: string, i: number): boolean {
+  let j = i - 1;
+  // Walk back over identifier characters [A-Za-z0-9_$]
+  while (j >= 0 && /[A-Za-z0-9_$]/.test(str[j])) {
+    j--;
+  }
+  // Must have consumed at least one char, and the first char of the word must be a letter/underscore/$
+  const wordStart = j + 1;
+  return wordStart < i && /[A-Za-z_$]/.test(str[wordStart]);
 }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -177,10 +177,11 @@ describe("findExports", () => {
       type: "declaration",
       names: ["a", "b"],
     },
-    "export const a: Map<string, Map<string, (x: string) => void>> = new Map(), b = 1": {
-      type: "declaration",
-      names: ["a", "b"],
-    },
+    "export const a: Map<string, Map<string, (x: string) => void>> = new Map(), b = 1":
+      {
+        type: "declaration",
+        names: ["a", "b"],
+      },
     "export const a: Map<(x: string) => void, string> = new Map(), b = 1": {
       type: "declaration",
       names: ["a", "b"],

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -169,6 +169,10 @@ describe("findExports", () => {
       name: "m",
       names: ["m"],
     },
+    "export const a = 1<2, b = 3": {
+      type: "declaration",
+      names: ["a", "b"],
+    },
   };
 
   for (const [input, test] of Object.entries(tests)) {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -159,6 +159,16 @@ describe("findExports", () => {
       type: "declaration",
       names: ["a", "b"],
     },
+    "export const nested = new Map<string, Handler<A, B>>()": {
+      type: "declaration",
+      name: "nested",
+      names: ["nested"],
+    },
+    "export const m = Map2<string, number>()": {
+      type: "declaration",
+      name: "m",
+      names: ["m"],
+    },
   };
 
   for (const [input, test] of Object.entries(tests)) {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -173,6 +173,18 @@ describe("findExports", () => {
       type: "declaration",
       names: ["a", "b"],
     },
+    "export const a: Map<string, (x: string) => void> = new Map(), b = 1": {
+      type: "declaration",
+      names: ["a", "b"],
+    },
+    "export const a: Map<string, Map<string, (x: string) => void>> = new Map(), b = 1": {
+      type: "declaration",
+      names: ["a", "b"],
+    },
+    "export const a: Map<(x: string) => void, string> = new Map(), b = 1": {
+      type: "declaration",
+      names: ["a", "b"],
+    },
   };
 
   for (const [input, test] of Object.entries(tests)) {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -145,6 +145,20 @@ describe("findExports", () => {
       name: "foo",
       names: ["foo"],
     },
+    "export const APP_MODE_MAP = new Map<string, IAppMode>()": {
+      type: "declaration",
+      name: "APP_MODE_MAP",
+      names: ["APP_MODE_MAP"],
+    },
+    "export const result = foo<Bar, Baz>(arg1, arg2)": {
+      type: "declaration",
+      name: "result",
+      names: ["result"],
+    },
+    "export const a = new Set<string>(), b = new Map<string, number>()": {
+      type: "declaration",
+      names: ["a", "b"],
+    },
   };
 
   for (const [input, test] of Object.entries(tests)) {


### PR DESCRIPTION
Fixes: https://github.com/nuxt/nuxt/issues/34644

---

Hi! 

`findExports` incorrectly extracts type parameters from generic expressions as export names.

For `export const APP_MODE_MAP = new Map<string, IAppMode>()`, the result was `names: ["APP_MODE_MAP", "IAppMode"]` instead of just `["APP_MODE_MAP"]`.

The comma inside `<string, IAppMode>` was treated as a declaration separator because angle bracket tracking only kicked in after `a : (type annotation)`. Generics in value position `(new Map<...>, foo<T>(...))` were never tracked.

The fix: also track `<` as a generic opener when preceded by an identifier character **([A-Za-z_$])**, which distinguishes `Map<T>` from `x < y`. 

This caused, as linked,  real issues downstream - in **Nuxt**, `scanDirExports` from **unimport** picked up `IAppMode` as a value export, which broke type checking when multiple imports.dirs were configured.

###  Tests
- All tests are green
- Added 3 new tests for this scenario 

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * More robust handling of angle-bracket generics: top-level identifier-based `<` now treated as generic openings and `>` ignores `>=`-like sequences, fixing comma/classification errors in declaration extraction.

* **Tests**
  * Added coverage for varied export patterns: generic types and calls, multi-declarator exports, map/set initializers, and ambiguous angle-bracket sequences.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->