### PR TITLE
fix: handle multiline comments in stripComments

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -10,7 +10,7 @@ const ESM_RE =
 const CJS_RE =
   /(?:[\s;]|^)(?:module\.exports\b|exports\.\w|require\s*\(|global\.\w)/m;
 
-const COMMENT_RE = /\/\*.+?\*\/|\/\/.*(?=[nr])/g;
+const COMMENT_RE = /\/\*[\s\S]*?\*\/|\/\/.*(?=[nr])/g;
 
 const BUILTIN_EXTENSIONS = new Set([".mjs", ".cjs", ".node", ".wasm"]);
 

--- a/test/syntax.test.ts
+++ b/test/syntax.test.ts
@@ -92,6 +92,10 @@ const staticTests = {
 const staticTestsWithComments = {
   '// They\'re exposed using "export import" so that types are passed along as expected\nmodule.exports={};':
     { hasESM: false, hasCJS: true, isMixed: false },
+  "/* export * */": { hasESM: false, hasCJS: false, isMixed: false },
+  "/* \n  export * \n*/": { hasESM: false, hasCJS: false, isMixed: false },
+  "/* \n  export * \n*/\nmodule.exports = {}":
+    { hasESM: false, hasCJS: true, isMixed: false },
 };
 
 describe("detectSyntax", () => {


### PR DESCRIPTION
## Summary

Fixes #279

Multiline block comments were not being stripped because the regex used `.+?` which doesn't match newline characters.

## Reproduction

```js
hasESMSyntax(`/* export * */`, { stripComments: true })     // false ✅
hasESMSyntax(`/* \n  export * \n*/`, { stripComments: true }) // true ❌ (should be false)
```

## Fix

```diff
- const COMMENT_RE = /\/\*.+?\*\/|\/\/.*(?=[nr])/g;
+ const COMMENT_RE = /\/\*[\s\S]*?\*\/|\/\/.*(?=[nr])/g;
```

`.+?` → `[\s\S]*?` matches any character including newlines (non-greedy).

## Tests

Added 3 test cases for multiline block comments. All 201 tests pass.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed multi-line comment handling during syntax detection when the stripComments option is enabled, improving accuracy of module syntax classification.

* **Tests**
  * Added test cases to validate multi-line comment handling in syntax detection.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->