### PR TITLE
fix(analyze): exclude member access from dynamic imports (#288)

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -250,7 +250,7 @@ export const ESM_STATIC_IMPORT_RE =
  * @example `import('module')`
  */
 export const DYNAMIC_IMPORT_RE =
-  /import\s*\((?<expression>(?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)/gm;
+  /(?<![\w$.])import\s*\((?<expression>(?:[^()]+|\((?:[^()]+|\([^()]*\))*\))*)\)/gm;
 const IMPORT_NAMED_TYPE_RE =
   /(?<=\s|^|;|})import\s*type\s+(?:[\s"']*(?<imports>[\w\t\n\r $*,/{}]+)from\s*)?["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][\s;]*/gm;
 

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -204,6 +204,10 @@ const dynamicTests = {
   },
   '// import("abc").then(r => r.default)': [],
   '/* import("abc").then(r => r.default) */': [],
+  // Member access should not be matched as a dynamic import (#288)
+  'Quill.import("blots/block/embed")': [],
+  'const foo = timport("foo")': [],
+  'obj?.import("x")': [],
 } as const;
 
 const TypeTests = {


### PR DESCRIPTION
## Summary

Fixes #288.

`findDynamicImports` / `DYNAMIC_IMPORT_RE` matched any `xxx.import(...)` call as a dynamic import, so expressions like `Quill.import('blots/block/embed')` or `obj?.import('x')` were wrongly reported as real dynamic imports.

The regex `/import\s*\(...\)/` had no boundary before `import`, so it matched:
- member access: `Quill.import('x')` → matched `import('x')`
- identifier tails: the body of `timport('foo')` (filtered only because acorn happened to tokenize the file cleanly — still a latent bug).

Added a negative lookbehind `(?<![\w$.])` so `import(` is only matched when `import` stands on its own — not after `.` / `?.` / `$` / another identifier char.

## Test plan

- [x] Added three cases to `dynamicTests` in `test/imports.test.ts` covering `Quill.import(...)`, `timport(...)`, and `obj?.import(...)` — all expected to produce zero matches.
- [x] Existing dynamic-import tests still pass (including `import("abc").then(...)` at start-of-string and after `=`).
- [x] `pnpm test` — 201/201 tests pass.
- [x] `pnpm lint` — clean.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **Bug Fixes**
  * Improved dynamic import detection accuracy with refined pattern matching to correctly handle property access and identifier scenarios.

* **Tests**
  * Added test coverage for edge cases including member access, optional chaining, and identifier patterns in dynamic imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->