### PR TITLE
fix: prevent EXPORT_DECAL_RE from crossing newlines into multi-line object literals

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -259,7 +259,7 @@ const IMPORT_NAMED_TYPE_RE =
  * @example `export const num = 1, str = 'hello'; export class Example {}`
  */
 export const EXPORT_DECAL_RE =
-  /\bexport\s+(?<declaration>(?:async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,\s*[\s\w:[\]{}]*[\w$\]}]+)*/g;
+  /\bexport\s+(?<declaration>(?:async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,[^\S\n]*[\w:[\]{}]*[\w$\]}]+)*/g;
 /**
  * Regular expression to match export declarations specifically for types, interfaces, and type aliases in TypeScript.
  * @example `export type Result = { success: boolean; }; export interface User { name: string; age: number; };`

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -258,6 +258,12 @@ const IMPORT_NAMED_TYPE_RE =
  * Regular expression to match various types of export declarations including variables, functions, and classes.
  * @example `export const num = 1, str = 'hello'; export class Example {}`
  */
+// EXPORT_DECAL_RE captures three groups: <declaration> (e.g. "const"), <name> (primary binding),
+// and <extraNames> for additional comma-separated siblings (e.g. `export const a = 1, b = 2`).
+// [^\S\n]* in extraNames intentionally allows only horizontal whitespace after each comma so the
+// group cannot cross a newline into a multi-line call argument. This means a sibling binding that
+// starts on the next line (`export const a = longFn(),\n  b = 1`) will not be captured — a known
+// limitation accepted to avoid false positives from object property keys (see unjs/mlly#303).
 export const EXPORT_DECAL_RE =
   /\bexport\s+(?<declaration>(?:async function\s*\*?|function\s*\*?|let|const enum|const|enum|var|class))\s+\*?(?<name>[\w$]+)(?<extraNames>.*,[^\S\n]*[\w:[\]{}]*[\w$\]}]+)*/g;
 /**

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -465,6 +465,14 @@ export { foo } from 'foo1';export { bar } from 'foo2';export * as foobar from 'f
     const matches = findExports(code);
     expect(matches).to.have.lengthOf(3);
   });
+
+  // https://github.com/unjs/mlly/issues/303
+  it("does not pick up object property keys from multi-line object literals as extra export names", () => {
+    const code = `export const useStore = defineStore('id', {\n  state: () => ({}),\n  actions: { foo() {} }\n})`;
+    const matches = findExports(code);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toEqual(["useStore"]);
+  });
 });
 
 describe("findTypeExports", () => {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -358,6 +358,14 @@ export { type AType, type B as BType, foo } from 'foo'
       ]
     `);
   });
+
+  // https://github.com/unjs/mlly/issues/303
+  it("does not pick up object property keys from multi-line object literals as extra export names", () => {
+    const code = `export const useStore = defineStore('id', {\n  state: () => ({}),\n  actions: { foo() {} }\n})`;
+    const matches = findExports(code);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].names).toEqual(["useStore"]);
+  });
 });
 
 describe("findExportNames", () => {
@@ -464,14 +472,6 @@ export { foo } from 'foo1';export { bar } from 'foo2';export * as foobar from 'f
 `;
     const matches = findExports(code);
     expect(matches).to.have.lengthOf(3);
-  });
-
-  // https://github.com/unjs/mlly/issues/303
-  it("does not pick up object property keys from multi-line object literals as extra export names", () => {
-    const code = `export const useStore = defineStore('id', {\n  state: () => ({}),\n  actions: { foo() {} }\n})`;
-    const matches = findExports(code);
-    expect(matches).toHaveLength(1);
-    expect(matches[0].names).toEqual(["useStore"]);
   });
 });
 


### PR DESCRIPTION
## Summary

Fixes #303, related to nuxt/nuxt#34997

`findExports` incorrectly picks up object property keys as named exports when scanning multi-line TypeScript files. The `extraNames` capture group in `EXPORT_DECAL_RE` used `\s*` and `[\s\w:[\]{}]*`, which allowed the regex to span across newlines into multi-line object literals passed as call arguments.

**Reproduction:**
```ts
findExports(`export const useStore = defineStore('id', {\n  state: () => ({}),\n  actions: { foo() {} }\n})`)
// before: ['useStore', 'actions']  ❌
// after:  ['useStore']             ✅
```

## Changes

- **`src/analyze.ts`:** In `EXPORT_DECAL_RE`, change the `extraNames` group:
  - `\s*` → `[^\S\n]*` (horizontal whitespace only — no newlines after comma)
  - `[\s\w:[\]{}]*` → `[\w:[\]{}]*` (drop `\s` to prevent crossing lines)
- **`test/exports.test.ts`:** Add regression test for the above case

## Test plan

- [x] New regression test fails before fix, passes after
- [x] All existing 199 tests continue to pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved export declaration pattern matching so multi-line object literals inside exported initializers no longer cause incorrect exported names to be detected.

* **Tests**
  * Added a regression test ensuring object property keys inside variable initializers are not reported as additional exports.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->