### PR TITLE
fix: revert export default class declaration entry

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -276,8 +276,6 @@ const EXPORT_STAR_RE =
   /\bexport\s*\*(?:\s*as\s+(?<name>[\w$]+)\s+)?\s*(?:\s*from\s*["']\s*(?<specifier>(?<="\s*)[^"]*[^\s"](?=\s*")|(?<='\s*)[^']*[^\s'](?=\s*'))\s*["'][^\n;]*)?/g;
 const EXPORT_DEFAULT_RE =
   /\bexport\s+default\s+(async function|function|class|true|false|\W|\d)|\bexport\s+default\s+(?<defaultName>.*)/g;
-const EXPORT_DEFAULT_CLASS_RE =
-  /\bexport\s+default\s+(?<declaration>class)\s+(?<name>[\w$]+)/g;
 const TYPE_RE = /^\s*?type\s/;
 
 /**
@@ -540,11 +538,6 @@ export function findExports(code: string): ESMExport[] {
     name: "default",
   });
 
-  // Find export default class
-  const defaultClassExports = matchAll(EXPORT_DEFAULT_CLASS_RE, code, {
-    type: "declaration",
-  });
-
   // Find export star
   const starExports: ESMExport[] = matchAll(EXPORT_STAR_RE, code, {
     type: "star",
@@ -557,7 +550,6 @@ export function findExports(code: string): ESMExport[] {
     ...namedExports,
     ...destructuredExports,
     ...defaultExport,
-    ...defaultClassExports,
     ...starExports,
   ]);
 

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -326,38 +326,6 @@ export { type AType, type B as BType, foo } from 'foo'
     expect(matches[0].names[0]).toEqual("foo");
     expect(matches[0].name).toEqual("foo");
   });
-
-  it("export default class", () => {
-    const code = `export default class Foo`;
-    const matches = findExports(code);
-    expect(matches).toMatchInlineSnapshot(`
-      [
-        {
-          "code": "export default class",
-          "defaultName": undefined,
-          "end": 20,
-          "name": "default",
-          "names": [
-            "default",
-          ],
-          "start": 0,
-          "type": "default",
-        },
-        {
-          "code": "export default class Foo",
-          "declaration": "class",
-          "declarationType": "class",
-          "end": 24,
-          "name": "Foo",
-          "names": [
-            "Foo",
-          ],
-          "start": 0,
-          "type": "declaration",
-        },
-      ]
-    `);
-  });
 });
 
 describe("findExportNames", () => {

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -326,6 +326,26 @@ export { type AType, type B as BType, foo } from 'foo'
     expect(matches[0].names[0]).toEqual("foo");
     expect(matches[0].name).toEqual("foo");
   });
+
+  it("export default class", () => {
+    const code = `export default class Foo`;
+    const matches = findExports(code);
+    expect(matches).toMatchInlineSnapshot(`
+      [
+        {
+          "code": "export default class",
+          "defaultName": undefined,
+          "end": 20,
+          "name": "default",
+          "names": [
+            "default",
+          ],
+          "start": 0,
+          "type": "default",
+        },
+      ]
+    `);
+  });
 });
 
 describe("findExportNames", () => {


### PR DESCRIPTION
This PR reverts #320, which made `findExports` return an extra `{ type: 'declaration' }` entry for default-exported classes alongside the default one.

## Impact on unimport

For every default-exported class, the extra entry collides with the default one in `unimport`'s `dedupeImports`, and the wrong one wins. The generated `.d.ts` then references a non-existent named export instead of `.default`.

Source:

```ts
// path.ts
export default class ClassName {}
```

Before:

```ts
const ClassName: typeof import('./path').ClassName
```

After:

```ts
const ClassName: typeof import('./path').default
```

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Modified default class export detection to use the general default export recognition pattern, affecting how these exports are reported in analysis results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->