### PR TITLE
fix(resolve): ignore null export targets

### DIFF
--- a/src/resolve.ts
+++ b/src/resolve.ts
@@ -290,14 +290,22 @@ function _findSubpath(subpath: string, exports: PackageJson["exports"]) {
 }
 
 function _flattenExports(
-  exports: Exclude<PackageJson["exports"], string> = {},
+  exports: Exclude<PackageJson["exports"], string> | null = {},
   parentSubpath = "./",
 ): { subpath: string; fsPath: string; condition?: string }[] {
+  if (exports === null) {
+    return [];
+  }
+
   return Object.entries(exports).flatMap(([key, value]) => {
     const [subpath, condition] = key.startsWith(".")
       ? [key.slice(1), undefined]
       : ["", key];
     const _subPath = joinURL(parentSubpath, subpath);
+
+    if (value === null) {
+      return [];
+    }
 
     if (typeof value === "string") {
       return [{ subpath: _subPath, fsPath: value, condition }];

--- a/test/fixture/package/node_modules/subpaths/package.json
+++ b/test/fixture/package/node_modules/subpaths/package.json
@@ -5,6 +5,11 @@
     ".": {
       "default": "./dist/index.mjs"
     },
+    "./types": {
+      "types": "./dist/types/index.d.ts",
+      "import": null,
+      "require": null
+    },
     "./subpath": {
       "default": "./dist/subpath.mjs"
     }


### PR DESCRIPTION
Fixes `lookupNodeModuleSubpath` crashing when a package `exports` map contains `null` targets.

`null` is a valid package exports target for disabling a condition or subpath. Previously `_flattenExports` recursively processed non-string values, so `null` targets eventually reached
`Object.entries(null)` and threw:

```txt
TypeError: Cannot convert undefined or null to object
```

This change treats null export targets as omitted while flattening exports.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved handling of package exports when exports are null, preventing potential errors in export resolution.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->