### PR TITLE
perf: replace `acorn` tokenizer with `js-tokens`

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,7 +27,7 @@
     "test:types": "tsc --noEmit"
   },
   "dependencies": {
-    "acorn": "^8.16.0",
+    "js-tokens": "^10.0.0",
     "pathe": "^2.0.3",
     "pkg-types": "^1.3.1",
     "ufo": "^1.6.4"

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -8,9 +8,9 @@ importers:
 
   .:
     dependencies:
-      acorn:
-        specifier: ^8.16.0
-        version: 8.16.0
+      js-tokens:
+        specifier: ^10.0.0
+        version: 10.0.0
       pathe:
         specifier: ^2.0.3
         version: 2.0.3

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -1,4 +1,4 @@
-import { tokenizer } from "acorn";
+import jsTokens from "js-tokens";
 import { matchAll, clearImports, getImportNames } from "./_utils";
 import { resolvePath, type ResolveOptions } from "./resolve";
 import { loadURL } from "./utils";
@@ -287,7 +287,7 @@ const TYPE_RE = /^\s*?type\s/;
  */
 export function findStaticImports(code: string): StaticImport[] {
   return _filterStatement(
-    _tryGetLocations(code, "import"),
+    _getLocations(code, "import"),
     matchAll(ESM_STATIC_IMPORT_RE, code, { type: "static" }),
   );
 }
@@ -299,7 +299,7 @@ export function findStaticImports(code: string): StaticImport[] {
  */
 export function findDynamicImports(code: string): DynamicImport[] {
   return _filterStatement(
-    _tryGetLocations(code, "import"),
+    _getLocations(code, "import"),
     matchAll(DYNAMIC_IMPORT_RE, code, { type: "dynamic" }),
   );
 }
@@ -565,7 +565,7 @@ export function findExports(code: string): ESMExport[] {
   if (exports.length === 0) {
     return [];
   }
-  const exportLocations = _tryGetLocations(code, "export");
+  const exportLocations = _getLocations(code, "export");
   if (exportLocations && exportLocations.length === 0) {
     return [];
   }
@@ -618,7 +618,7 @@ export function findTypeExports(code: string): ESMExport[] {
   if (exports.length === 0) {
     return [];
   }
-  const exportLocations = _tryGetLocations(code, "export");
+  const exportLocations = _getLocations(code, "export");
   if (exportLocations && exportLocations.length === 0) {
     return [];
   }
@@ -748,29 +748,14 @@ function _filterStatement<T extends TokenLocation>(
   });
 }
 
-function _tryGetLocations(code: string, label: string) {
-  try {
-    return _getLocations(code, label);
-  } catch {
-    // Ignore error
-  }
-}
-
 function _getLocations(code: string, label: string) {
-  const tokens = tokenizer(code, {
-    ecmaVersion: "latest",
-    sourceType: "module",
-    allowHashBang: true,
-    allowAwaitOutsideFunction: true,
-    allowImportExportEverywhere: true,
-  });
   const locations: TokenLocation[] = [];
-  for (const token of tokens) {
-    if (token.type.label === label) {
-      locations.push({
-        start: token.start,
-        end: token.end,
-      });
+  let offset = 0;
+  for (const token of jsTokens(code)) {
+    const start = offset;
+    offset += token.value.length;
+    if (token.type === "IdentifierName" && token.value === label) {
+      locations.push({ start, end: offset });
     }
   }
   return locations;

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -316,6 +316,16 @@ export default function useMain() {}
     expect(matches2).toEqual(matches1);
   });
 
+  it("filters commented out exports in non-parseable (TypeScript) code", () => {
+    const code = `
+// export const commented: string = "a"
+export const foo: Map<string, number> = new Map()
+`;
+    const matches = findExports(code);
+    expect(matches).toHaveLength(1);
+    expect(matches[0].name).toEqual("foo");
+  });
+
   it("ignore export type", () => {
     const code = `
 export { type AType, type B as BType, foo } from 'foo'


### PR DESCRIPTION
spotted an opportunity to improve `mlly`'s install size

`acorn` is 552 KB, `js-tokens` is 16 KB and already in the tree for vitest + unimport (via `strip-literal`)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of imports and exports in JavaScript and TypeScript code, including files with syntax that cannot be fully parsed.
  * Prevented commented-out exports from being incorrectly detected.


<!-- end of auto-generated comment: release notes by coderabbit.ai -->