### PR TITLE
fix(types): make StaticImport/TypeImport imports optional

### DIFF
--- a/src/_utils.ts
+++ b/src/_utils.ts
@@ -24,7 +24,7 @@ export function matchAll(regex: RegExp, string: string, addition: any) {
   return matches;
 }
 
-export function clearImports(imports: string) {
+export function clearImports(imports: string | undefined) {
   return (imports || "")
     .replace(/\/\/[^\n]*\n|\/\*.*\*\//g, "")
     .replace(/\s+/g, " ");

--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -40,8 +40,10 @@ export interface StaticImport extends ESMImport {
 
   /**
    * Contains the entire import statement as a string, excluding the module specifier.
+   * `undefined` for side effect imports such as `import "styles.css"`, which have no
+   * import clause.
    */
-  imports: string;
+  imports?: string;
 
   /**
    * The module specifier from which imports are being brought in.
@@ -102,8 +104,10 @@ export interface TypeImport extends Omit<ESMImport, "type"> {
 
   /**
    * Contains the entire type import statement as a string, excluding the module specifier.
+   * `undefined` for side effect imports such as `import "styles.css"`, which have no
+   * import clause.
    */
-  imports: string;
+  imports?: string;
 
   /**
    * The module specifier from which to import types.
@@ -314,7 +318,7 @@ export function findTypeImports(code: string): TypeImport[] {
   return [
     ...matchAll(IMPORT_NAMED_TYPE_RE, code, { type: "type" }),
     ...matchAll(ESM_STATIC_IMPORT_RE, code, { type: "static" }).filter(
-      (match) => /[^A-Za-z]type\s/.test(match.imports),
+      (match) => /[^A-Za-z]type\s/.test(match.imports ?? ""),
     ),
   ];
 }

--- a/test/imports.test.ts
+++ b/test/imports.test.ts
@@ -282,6 +282,14 @@ describe("findStaticImports", () => {
       }
     });
   }
+
+  it("side effect import has no import clause", () => {
+    const [match] = findStaticImports('import "styles.css";');
+    expect(match.specifier).to.equal("styles.css");
+    // A side effect import has no import clause, so `imports` is `undefined`.
+    expect(match.imports).toBeUndefined();
+    expect(parseStaticImport(match).namedImports).to.eql({});
+  });
 });
 
 describe("findDynamicImports", () => {


### PR DESCRIPTION
Fixes #349

### Problem

`ESM_STATIC_IMPORT_RE` has an **optional** `imports` capture group, because a side effect import has no import clause:

```
import\s*(?:[\s"']*(?<imports>...)from\s*)?["']...
                                          ^ optional
```

So for a side effect import the property is simply absent at runtime:

```js
findStaticImports('import "styles.css";')[0].imports // => undefined
```

But `StaticImport['imports']` (and `TypeImport['imports']`) declared it as a required `string`. TypeScript therefore told consumers the value was always present, and code like `match.imports.includes("type")` type-checked cleanly while throwing at runtime.

The existing suite has a side effect import case, but it only asserts the `specifier`, so it never caught the mismatch.

### Fix

- `imports` is now `imports?: string` on `StaticImport` and `TypeImport`, with a doc comment explaining when it is `undefined`.
- `clearImports` accepts `string | undefined`. Its body already did `(imports || "")`, so this only makes the signature match the behaviour it already had — `parseStaticImport` / `parseTypeImport` keep working unchanged on side effect imports.
- `findTypeImports` guards the filter with `match.imports ?? ""`, which was the one place that fed the possibly-undefined value straight into `RegExp.test` (it previously relied on `test` stringifying `undefined` to `"undefined"`).
- Added a regression test asserting `imports` is `undefined` and that `parseStaticImport` still yields empty `namedImports`.

### Compatibility

This is a type-only change for a value that was already `undefined` at runtime. It is strictly more accurate, though downstream code that assumed a non-optional `string` under `strict` will now surface the guard it was always missing — which is the point of the issue.

### Validation

- `vitest run` — 199/199 pass (6 files)
- `tsc --noEmit` — clean
- `eslint src test` — clean
- `prettier --check src test` — clean
- `unbuild` — builds successfully


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added support for side-effect imports without named import clauses.
  * Import analysis now safely handles missing import details.

* **Bug Fixes**
  * Improved handling of undefined import values while preserving existing cleanup behavior.

* **Tests**
  * Added coverage confirming side-effect imports are represented correctly and parsed with no named imports.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->