### PR TITLE
fix(analyze): handle circular star exports

### DIFF
--- a/src/analyze.ts
+++ b/src/analyze.ts
@@ -697,7 +697,20 @@ export async function resolveModuleExportNames(
   id: string,
   options?: ResolveOptions,
 ): Promise<string[]> {
+  return _resolveModuleExportNames(id, options, new Set());
+}
+
+async function _resolveModuleExportNames(
+  id: string,
+  options: ResolveOptions | undefined,
+  visited: Set<string>,
+): Promise<string[]> {
   const url = await resolvePath(id, options);
+  if (visited.has(url)) {
+    return [];
+  }
+  visited.add(url);
+
   const code = await loadURL(url);
   const exports = findExports(code);
 
@@ -711,10 +724,14 @@ export async function resolveModuleExportNames(
     if (exp.type !== "star" || !exp.specifier) {
       continue;
     }
-    const subExports = await resolveModuleExportNames(exp.specifier, {
-      ...options,
-      url,
-    });
+    const subExports = await _resolveModuleExportNames(
+      exp.specifier,
+      {
+        ...options,
+        url,
+      },
+      visited,
+    );
     for (const subExport of subExports) {
       exportNames.add(subExport);
     }

--- a/test/exports.test.ts
+++ b/test/exports.test.ts
@@ -444,6 +444,13 @@ describe("resolveModuleExportNames", () => {
     `);
   });
 
+  it("handles circular star exports", async () => {
+    const names = await resolveModuleExportNames(
+      new URL("fixture/circular/a.mjs", import.meta.url).toString(),
+    );
+    expect(names.sort()).toEqual(["a", "b"]);
+  });
+
   it("star exports with package", async () => {
     expect(
       await resolveModuleExportNames(

--- a/test/fixture/circular/a.mjs
+++ b/test/fixture/circular/a.mjs
@@ -1,0 +1,2 @@
+export const a = 1;
+export * from "./b.mjs";

--- a/test/fixture/circular/b.mjs
+++ b/test/fixture/circular/b.mjs
@@ -1,0 +1,2 @@
+export const b = 2;
+export * from "./a.mjs";


### PR DESCRIPTION
## Problem

`resolveModuleExportNames` recursively follows `export *` declarations without tracking modules already visited. A valid circular re-export graph therefore never resolves.

## Fix

Track resolved module URLs during one traversal and stop revisiting a URL. The public API is unchanged, and each module's export names are still unioned once.

## Tests

- `pnpm test` — passed (199 tests)
- `pnpm vitest --coverage` — passed (199 tests)
- `pnpm build` — passed
- Self-cycle and three-module-cycle smoke cases — passed

## Compatibility

The change only terminates previously non-terminating circular graphs and preserves the existing result for acyclic graphs.

## Related issue

Independent reproduction; no issue linked.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved module export resolution for circular re-exports.
  * Prevented infinite loops when modules re-export each other.

* **Tests**
  * Added coverage confirming that exports from circular module relationships resolve correctly.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->