### PR TITLE
feat: expose /resolver subpath (#274)

### DIFF
--- a/build.config.ts
+++ b/build.config.ts
@@ -6,5 +6,5 @@ export default defineBuildConfig({
     emitCJS: true,
     inlineDependencies: true,
   },
-  entries: ["src/index"],
+  entries: ["src/index", "src/resolver"],
 });

--- a/package.json
+++ b/package.json
@@ -7,9 +7,16 @@
   "sideEffects": false,
   "type": "module",
   "exports": {
-    "types": "./dist/index.d.ts",
-    "import": "./dist/index.mjs",
-    "require": "./dist/index.cjs"
+    ".": {
+      "types": "./dist/index.d.ts",
+      "import": "./dist/index.mjs",
+      "require": "./dist/index.cjs"
+    },
+    "./resolver": {
+      "types": "./dist/resolver.d.ts",
+      "import": "./dist/resolver.mjs",
+      "require": "./dist/resolver.cjs"
+    }
   },
   "main": "./dist/index.cjs",
   "module": "./dist/index.mjs",

--- a/src/resolver.ts
+++ b/src/resolver.ts
@@ -1,0 +1,1 @@
+export * from "./resolve";

--- a/test/resolver.test.ts
+++ b/test/resolver.test.ts
@@ -1,0 +1,12 @@
+import { describe, it, expect } from "vitest";
+import * as resolver from "../src/resolver";
+
+describe("resolver subpath", () => {
+  it("exports resolver methods", () => {
+    expect(typeof resolver.resolve).toBe("function");
+    expect(typeof resolver.resolvePath).toBe("function");
+    expect(typeof resolver.resolveSync).toBe("function");
+    expect(typeof resolver.resolvePathSync).toBe("function");
+    expect(typeof resolver.createResolve).toBe("function");
+  });
+});


### PR DESCRIPTION
Resolves #274

### Motivation
As noted in #274 and unjs/pkg-types#191, consumers that only need module resolution logic (like `resolvePath` or `resolve`) currently import the main entrypoint which eagerly loads and initializes AST parsing and evaluation utilities (`acorn`, syntax analyzers, etc.). Exposing a dedicated `/resolver` subpath allows downstream packages to import only ESM resolution logic for faster startup and smaller footprints.

### Changes
- Added `src/resolver.ts` re-exporting resolution functions from `src/resolve.ts`.
- Added `src/resolver` to `entries` in `build.config.ts` to emit `dist/resolver.{mjs,cjs,d.ts}`.
- Exposed `"./resolver"` in `package.json` `exports`.
- Added tests in `test/resolver.test.ts` verifying resolver exports.

### Testing
- Passed `pnpm test` (199 tests), `pnpm test:types`, `pnpm lint`, and verified `pnpm build` output.

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a dedicated `resolver` package subpath for accessing resolver utilities.
  * Resolver utilities are available through both ES module and CommonJS imports, with TypeScript support.

* **Tests**
  * Added coverage to verify the resolver subpath exposes the expected functions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->