### PR TITLE
fix(syntax): validate ESM detection against tokens

### DIFF
--- a/src/syntax.ts
+++ b/src/syntax.ts
@@ -1,4 +1,5 @@
 import { promises as fsp } from "node:fs";
+import { tokenizer } from "acorn";
 import { extname } from "pathe";
 import { readPackageJSON } from "pkg-types";
 import { ResolveOptions, resolvePath } from "./resolve";
@@ -36,10 +37,72 @@ export function hasESMSyntax(
   code: string,
   opts: DetectSyntaxOptions = {},
 ): boolean {
-  if (opts.stripComments) {
-    code = code.replace(COMMENT_RE, "");
+  if (!/\b(?:import|export)\b/.test(code)) {
+    return false;
   }
-  return ESM_RE.test(code);
+
+  let commentMatch = false;
+  try {
+    const tokens = tokenizer(code, {
+      ecmaVersion: "latest",
+      sourceType: "module",
+      allowHashBang: true,
+      allowAwaitOutsideFunction: true,
+      allowImportExportEverywhere: true,
+      onComment(_block, _text, start, end) {
+        if (!opts.stripComments) {
+          commentMatch ||= ESM_RE.test(code.slice(start, end));
+        }
+      },
+    });
+    let previousLabel: string | undefined;
+    for (const token of tokens) {
+      if (commentMatch) {
+        return true;
+      }
+      const label = token.type.label;
+      const memberAccess = previousLabel === "." || previousLabel === "?.";
+      previousLabel = label;
+      if (memberAccess) {
+        continue;
+      }
+      if (label === "import") {
+        let next = tokens.getToken();
+        if (["string", "*", "{"].includes(next.type.label)) {
+          return true;
+        }
+        if (next.type.label === ".") {
+          const property = tokens.getToken();
+          if (code.slice(property.start, property.end) === "meta") return true;
+        }
+        while (["name", "*", ",", "{", "}"].includes(next.type.label)) {
+          if (code.slice(next.start, next.end) === "from") {
+            return true;
+          }
+          next = tokens.getToken();
+        }
+      } else if (label === "export") {
+        const next = tokens.getToken();
+        if (
+          ["*", "{", "default", "class", "function", "const", "var"].includes(
+            next.type.label,
+          ) ||
+          (next.type.label === "name" &&
+            ["let", "type"].includes(code.slice(next.start, next.end))) ||
+          (code.slice(next.start, next.end) === "async" &&
+            tokens.getToken().type.label === "function")
+        ) {
+          return true;
+        }
+      }
+    }
+    return commentMatch;
+  } catch {
+    // Preserve heuristic detection for syntax the tokenizer cannot read.
+    return ESM_RE.test(
+      opts.stripComments ? code.replace(COMMENT_RE, "") : code,
+    );
+  }
 }
 
 /**
@@ -67,12 +130,8 @@ export function hasCJSSyntax(
  * @returns {object} An object indicating the presence of ESM syntax (`hasESM`), CJS syntax (`hasCJS`) and whether both syntaxes are present (`isMixed`).
  */
 export function detectSyntax(code: string, opts: DetectSyntaxOptions = {}) {
-  if (opts.stripComments) {
-    code = code.replace(COMMENT_RE, "");
-  }
-  // We strip comments once hence not passing opts down to hasESMSyntax and hasCJSSyntax
-  const hasESM = hasESMSyntax(code, {});
-  const hasCJS = hasCJSSyntax(code, {});
+  const hasESM = hasESMSyntax(code, opts);
+  const hasCJS = hasCJSSyntax(code, opts);
 
   return {
     hasESM,

--- a/test/fixture/imports/js-cjs-syntax-text/index.js
+++ b/test/fixture/imports/js-cjs-syntax-text/index.js
@@ -1,0 +1,5 @@
+module.exports = {
+  diagnostic: "Cannot use 'export import' here",
+  example: "example export default value",
+  template: `example import "package" text`,
+};

--- a/test/fixture/imports/js-cjs-syntax-text/package.json
+++ b/test/fixture/imports/js-cjs-syntax-text/package.json
@@ -1,0 +1,5 @@
+{
+  "name": "js-cjs-syntax-text",
+  "version": "1.0.0",
+  "main": "index.js"
+}

--- a/test/syntax.test.ts
+++ b/test/syntax.test.ts
@@ -1,6 +1,6 @@
 import { join } from "pathe";
 import { describe, it, expect } from "vitest";
-import { detectSyntax, isValidNodeImport } from "../src";
+import { detectSyntax, hasESMSyntax, isValidNodeImport } from "../src";
 
 const staticTests = {
   // ESM
@@ -112,6 +112,71 @@ describe("detectSyntax (with comment)", () => {
   }
 });
 
+describe.each([{}, { stripComments: true }])(
+  "ESM token detection (%j)",
+  (opts) => {
+    it.each([
+      `module.exports = "example export default value";`,
+      `module.exports = "Cannot use 'export import' here";`,
+      `module.exports = 'example import "package" text';`,
+      "module.exports = `example export default text`;",
+      'module.exports = `example ${" export default text"}`;',
+      "module.exports = / export default /;",
+      String.raw`module.exports = "escaped \" export default text";`,
+      "module.exports = fn(\n importingFile,\n fromCacheOnly\n);",
+      'module.exports = object.import("package");',
+      "module.exports = object?.export;",
+    ])("ignores non-syntax in %s", (code) => {
+      expect(hasESMSyntax(code, opts)).toBe(false);
+      expect(detectSyntax(code, opts)).toEqual({
+        hasESM: false,
+        hasCJS: true,
+        isMixed: false,
+      });
+    });
+
+    it.each([
+      'const text = " export default fake"; export const value = 1;',
+      'const text = " export default fake"; import "package";',
+      'importingFile\nimport value from "package";',
+      'import/* comment */"package";',
+      'import /* comment */ value /* comment */ from "package";',
+      "export/* comment */const value = 1;",
+      "const text = `raw ${ import.meta.url }`;",
+      'const start = "/* ";import foo from "bar";const end = " */";',
+      "export class",
+    ])("retains actual syntax in %s", (code) => {
+      expect(hasESMSyntax(code, opts)).toBe(true);
+      expect(detectSyntax(code, opts).hasESM).toBe(true);
+    });
+
+    it("does not classify a dynamic import as ESM", () => {
+      expect(hasESMSyntax('module.exports = import("package");', opts)).toBe(
+        false,
+      );
+    });
+
+    it("retains the heuristic for input the tokenizer cannot read", () => {
+      expect(hasESMSyntax("@decorator\nexport class Example {}", opts)).toBe(
+        true,
+      );
+    });
+  },
+);
+
+describe("ESM comments", () => {
+  it.each([
+    "// export default example\nmodule.exports = {};",
+    "/*\n export default example\n*/\nmodule.exports = {};",
+    "module.exports = `text ${ /* export default example */ 1 }`;",
+  ])("preserves the opt-in comment behavior for %s", (code) => {
+    expect(hasESMSyntax(code)).toBe(true);
+    expect(detectSyntax(code).hasESM).toBe(true);
+    expect(hasESMSyntax(code, { stripComments: true })).toBe(false);
+    expect(detectSyntax(code, { stripComments: true }).hasESM).toBe(false);
+  });
+});
+
 const nodeImportTests = {
   "node:fs": true,
   fs: true,
@@ -127,6 +192,7 @@ const nodeImportTests = {
   [join(import.meta.url, "../fixture/imports/esm")]: true,
   [join(import.meta.url, "../fixture/imports/esm-module")]: true,
   [join(import.meta.url, "../fixture/imports/js-cjs")]: true,
+  [join(import.meta.url, "../fixture/imports/js-cjs-syntax-text")]: true,
   [join(import.meta.url, "../fixture/imports/js-esm")]: false,
   [join(import.meta.url, "../fixture/imports/js-esm/es/index.mjs")]: true,
   [join(import.meta.url, "../fixture/imports/js-esm/es/index.js")]: false,
@@ -134,6 +200,24 @@ const nodeImportTests = {
 };
 
 describe("isValidNodeImport", () => {
+  it("ignores non-syntax with comments stripped", async () => {
+    expect(
+      await isValidNodeImport(
+        join(import.meta.url, "../fixture/imports/js-cjs-syntax-text"),
+        { stripComments: true },
+      ),
+    ).toBe(true);
+  });
+
+  it("preserves the comment option when validating CommonJS", async () => {
+    const id = join(import.meta.url, "../fixture/imports/js-cjs");
+    const code = "/*\n export default example\n*/\nmodule.exports = {};";
+    expect(await isValidNodeImport(id, { code })).toBe(false);
+    expect(await isValidNodeImport(id, { code, stripComments: true })).toBe(
+      true,
+    );
+  });
+
   for (const [input, result] of Object.entries(nodeImportTests)) {
     it(input, async () => {
       try {


### PR DESCRIPTION
### 🔗 Linked issue

Resolves [unjs/mlly#369](https://github.com/unjs/mlly/issues/369).
Related consumer fix: [nitrojs/nitro#4614](https://github.com/nitrojs/nitro/pull/4614), tracking [nitrojs/nitro#4613](https://github.com/nitrojs/nitro/issues/4613).

### ❓ Type of change

- [x] 🐞 Bug fix

### 📚 Description

`hasESMSyntax('module.exports = "example export default value";')` currently returns true. This incorrectly rejects valid CommonJS in `isValidNodeImport`, including the TypeScript compiler that Nitro then bundles into an incompatible ESM chunk.

Use the existing Acorn tokenizer to distinguish executable import/export syntax from strings, template text, regex literals, identifier prefixes, and member access. A keyword check retains the inexpensive no-candidate path. Token inspection also preserves real syntax separated by comments and actual `import.meta` inside template expressions. Keep the previous heuristic fallback for input Acorn cannot tokenize.

Public signatures and the opt-in `stripComments` default remain unchanged. With the option enabled, ESM detection ignores actual comment spans without deleting comment-like text from strings. `detectSyntax` passes the original source/options to its helpers; CommonJS detection is otherwise unchanged. No dependency is added.

This is distinct from the general comment-stripping fixes in [unjs/mlly#279](https://github.com/unjs/mlly/issues/279) / [unjs/mlly#367](https://github.com/unjs/mlly/pull/367). It uses Acorn already on main rather than incorporating the proposed dependency replacement in [unjs/mlly#361](https://github.com/unjs/mlly/pull/361).

### Validation

- [Linux and Windows qualification](https://github.com/benpsnyder/nitro/actions/runs/34663991217): 16 packed runtime cases pass on each OS, including Vite 6–8. The fork-only workflow builds mlly `ab98fb243603b14afbffee3f21dea4337c2b7bae` and Nitro `d605a55cf7e148a79eb6dd61537ca70d87ed5e6d`, runs the mlly suite and Nitro resolver tests, and uploads JSON receipts. This is independent qualification, not upstream CI approval.
- The initial regression set produced 21 failures against unchanged main; the final expanded suite passes 246 tests.
- `pnpm test` (lint, formatting, types, Vitest), `pnpm build`, and packed ESM output passed locally on Node 24.15.0 / Linux.
- Coverage includes escaped strings, templates and expressions, regex literals, identifier prefixes, member access, comment-separated declarations, both comment options, dynamic imports, incomplete input, and file-backed `isValidNodeImport` fixtures. Existing mixed-module rejection remains covered.
- With TypeScript 6.0.3, the published validator returns false even with `stripComments: true`. Packed fixed mlly returns true with that option and still returns false by default because the compiler contains ESM-looking comments.
- A paired packed Nitro 2 fix that opts into comment stripping returns TypeScript 6.0.3 in development and relocated production output, including legacy externals. Baseline, mlly-only, and Nitro-only production cases each retain the original HTTP 500. Removing the compiler import removes its output dependency.

### Performance tradeoff

Node 24.15.0/Linux, median of five batches, same process: a small CommonJS input was approximately 0.057 microseconds per call (baseline 0.101); a small ESM input was 1.80 microseconds (baseline 0.073). The 9.14 MB TypeScript compiler took approximately 166 ms to inspect versus 11 ms for the old incorrect regex result. These are local microbenchmarks, not whole-build speed claims. The added token scan is the cost of validating candidates on large files.

### 📝 Checklist

- [x] Linked issue and minimal reproduction.
- [x] Regression tests and existing suite pass locally.
- [x] Public signatures/defaults preserved; no new dependency.
- [ ] Upstream CI and maintainer review.

Draft while upstream review and coordination with the Nitro consumer release remain pending. Prepared with OpenAI Codex.


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved detection of ECMAScript module syntax for greater accuracy.
  * Reduced false positives when import/export-like text appears in strings, templates, regular expressions, function calls, property access, or comments.
  * Improved handling of dynamic imports and CommonJS files containing syntax-like text.
  * Preserved comment-handling options during syntax validation.

* **Tests**
  * Expanded coverage for syntax detection, comment handling, dynamic imports, and CommonJS compatibility.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->